### PR TITLE
add install shell script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,10 +19,9 @@ sudo apt-get update
 sudo apt-get install -y  docker-ce docker-ce-cli containerd.io docker-compose-plugin
 sudo groupadd -f docker
 sudo usermod -aG docker $USER
-
-# these two lines avoid the docker newgrp command from hanging the shell script
-/usr/bin/newgrp docker <<EONG
-#!/bin/bash
+if [ $(id -gn) != docker ]; then
+  exec sg $group "$0 $*"
+fi
 
 echo "Testing Docker Install"
 if docker run hello-world ; then
@@ -71,5 +70,4 @@ else
     exit
 fi
 
-echo “Set up success! You may need to run `newgrp docker` if your shell session has not been reset.
-EONG
+echo "Set up success! You may need to run `newgrp docker` if your shell session has not been reset."


### PR DESCRIPTION
First pass at install script.

After running this script on a fresh g5 instance I am able to run the setup commands in the LabDAO diffdock repo and pass the ```test.sh``` example

The p2 and g4 instance types did not have enough vRAM to run diffdock. I had to a personal AWS account, I requested G5 access on the LabDAO AWS account. https://support.console.aws.amazon.com/support/home#/case/?displayId=11831062061&language=en

<img width="561" alt="Screen Shot 2023-01-23 at 11 09 28 PM" src="https://user-images.githubusercontent.com/9427089/214217029-f1479e87-6b76-48a9-9656-5f4056cabdd2.png">
