### PR TITLE
make cli use direct ipfs post

### DIFF
--- a/cmd/plex/instruction.go
+++ b/cmd/plex/instruction.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/labdao/plex/internal/ipfs"
 )
 
 type Instruction struct {
@@ -22,7 +24,7 @@ func CreateInstruction(app string, instuctionFilePath, inputDirPath string, para
 	}
 	instruction.Params = overwriteParams(instruction.Params, paramOverrides)
 	instruction.Cmd = formatCmd(instruction.Cmd, instruction.Params)
-	cid, err := CreateInputCID(inputDirPath, instruction.Cmd)
+	cid, err := ipfs.AddDirHttp(os.Getenv("IPFS_NODE_URL"), inputDirPath)
 	if err != nil {
 		return instruction, err
 	}

--- a/cmd/plex/instruction_test.go
+++ b/cmd/plex/instruction_test.go
@@ -9,7 +9,7 @@ import (
 func TestCreateInstruction(t *testing.T) {
 	want := Instruction{
 		App:       "simpdock",
-		InputCIDs: []string{"bafybeifzg6egpgb6wi47cayzlltjcdlglls7qtteuqzbrecpiyzyfipuzi"},
+		InputCIDs: []string{"QmWVKoVYBWHWdRLrL8Td5kUpqN2qH6zQ5piwtdCE1fjSYt"},
 		Container: "simpdock:v1",
 		Params:    map[string]string{"layers": "33", "steps": "9000", "scifimode": "Y"},
 		Cmd:       "python -m inference -l 33 -s 9000 && python -m run --scifimode Y",


### PR DESCRIPTION
This moves the implementation of directly posting to IPFS.

I put our default IPFS node in the Discord channel. 

https://www.loom.com/share/c9e57bef37af4d74ae2380777c1b42ba

server side stuff
```
ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST"]'
ipfs config Pinning.Recursive true

ipfs daemon --routing=dhtclient
```