### PR TITLE
115 create a local flag that returns a docker command based on the plex input to facilitate debugging of apps

### DIFF
--- a/cmd/plex/instruction.go
+++ b/cmd/plex/instruction.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"github.com/labdao/plex/internal/ipfs"
 )
 
 type Instruction struct {
@@ -17,21 +15,13 @@ type Instruction struct {
 	Cmd       string            `json:"cmd"`
 }
 
-func CreateInstruction(app string, instuctionFilePath, inputDirPath string, paramOverrides map[string]string) (Instruction, error) {
+func CreateInstruction(app string, instuctionFilePath, cid string, paramOverrides map[string]string) (Instruction, error) {
 	instruction, err := ReadInstructions(app, instuctionFilePath)
 	if err != nil {
 		return instruction, err
 	}
 	instruction.Params = overwriteParams(instruction.Params, paramOverrides)
 	instruction.Cmd = formatCmd(instruction.Cmd, instruction.Params)
-	ipfsNodeUrl, err := ipfs.DeriveIpfsNodeUrl()
-	if err != nil {
-		return instruction, err
-	}
-	cid, err := ipfs.AddDirHttp(ipfsNodeUrl, inputDirPath)
-	if err != nil {
-		return instruction, err
-	}
 	instruction.InputCIDs = append(instruction.InputCIDs, cid)
 	return instruction, nil
 }

--- a/cmd/plex/instruction_test.go
+++ b/cmd/plex/instruction_test.go
@@ -14,7 +14,7 @@ func TestCreateInstruction(t *testing.T) {
 		Params:    map[string]string{"layers": "33", "steps": "9000", "scifimode": "Y"},
 		Cmd:       "python -m inference -l 33 -s 9000 && python -m run --scifimode Y",
 	}
-	got, err := CreateInstruction("simpdock", "../../testdata/test_instruction_template.jsonl", "../../testdata/ipfs_test", map[string]string{"steps": "9000", "scifimode": "Y"})
+	got, err := CreateInstruction("simpdock", "../../testdata/test_instruction_template.jsonl", "QmWVKoVYBWHWdRLrL8Td5kUpqN2qH6zQ5piwtdCE1fjSYt", map[string]string{"steps": "9000", "scifimode": "Y"})
 	if err != nil {
 		t.Errorf(fmt.Sprint(err))
 	}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -1,7 +1,9 @@
 package docker
 
 import (
+	"bufio"
 	"fmt"
+	"os/exec"
 	"path/filepath"
 )
 
@@ -11,5 +13,32 @@ func InstructionToDockerCmd(container, cmd, jobDir string, gpu bool) string {
 	if gpu {
 		gpuFlag = "--gpus"
 	}
-	return fmt.Sprintf("docker run %s -v %s:/inputs -v %s:/outputs %s -- /bin/bash -c '%s'", gpuFlag, jobDir, outputsDir, container, cmd)
+	return fmt.Sprintf("docker run %s -v %s:/inputs -v %s:/outputs %s /bin/bash -c '%s'", gpuFlag, jobDir, outputsDir, container, cmd)
+}
+
+func RunDockerCmd(container, cmd, jobDir string, gpu bool) error {
+	dockerCmd := InstructionToDockerCmd(container, cmd, jobDir, gpu)
+
+	// make output dir
+
+	cmdExec := exec.Command(dockerCmd)
+
+	stdout, err := cmdExec.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmdExec.Start(); err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		fmt.Println(scanner.Text())
+	}
+
+	if err := cmdExec.Wait(); err != nil {
+		return err
+	}
+	return err
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -1,9 +1,7 @@
 package docker
 
 import (
-	"bufio"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 )
 
@@ -14,31 +12,4 @@ func InstructionToDockerCmd(container, cmd, jobDir string, gpu bool) string {
 		gpuFlag = "--gpus"
 	}
 	return fmt.Sprintf("docker run %s -v %s:/inputs -v %s:/outputs %s /bin/bash -c '%s'", gpuFlag, jobDir, outputsDir, container, cmd)
-}
-
-func RunDockerCmd(container, cmd, jobDir string, gpu bool) error {
-	dockerCmd := InstructionToDockerCmd(container, cmd, jobDir, gpu)
-
-	// make output dir
-
-	cmdExec := exec.Command(dockerCmd)
-
-	stdout, err := cmdExec.StdoutPipe()
-	if err != nil {
-		return err
-	}
-
-	if err := cmdExec.Start(); err != nil {
-		return err
-	}
-
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		fmt.Println(scanner.Text())
-	}
-
-	if err := cmdExec.Wait(); err != nil {
-		return err
-	}
-	return err
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -1,0 +1,15 @@
+package docker
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+func InstructionToDockerCmd(container, cmd, jobDir string, gpu bool) string {
+	outputsDir := filepath.Join(jobDir, "outputs")
+	gpuFlag := ""
+	if gpu {
+		gpuFlag = "--gpus"
+	}
+	return fmt.Sprintf("docker run %s -v %s:/inputs -v %s:/outputs %s -- /bin/bash -c '%s'", gpuFlag, jobDir, outputsDir, container, cmd)
+}

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -6,9 +6,13 @@ import (
 )
 
 func TestInstructionToDockerCmd(t *testing.T) {
-	want := "docker run --gpus -v home/job-dir:/inputs -v home/job-dir/outputs:/outputs mycontainer -- /bin/bash -c 'python -m molbind'"
+	want := "docker run --gpus -v home/job-dir:/inputs -v home/job-dir/outputs:/outputs mycontainer /bin/bash -c 'python -m molbind'"
 	got := InstructionToDockerCmd("mycontainer", "python -m molbind", "home/job-dir", true)
 	if want != got {
 		t.Errorf("got = %s; wanted %s", fmt.Sprint(got), fmt.Sprint(want))
 	}
+}
+
+func TestRunDockerCmd(t *testing.T) {
+
 }

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -12,7 +12,3 @@ func TestInstructionToDockerCmd(t *testing.T) {
 		t.Errorf("got = %s; wanted %s", fmt.Sprint(got), fmt.Sprint(want))
 	}
 }
-
-func TestRunDockerCmd(t *testing.T) {
-
-}

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -1,0 +1,14 @@
+package docker
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestInstructionToDockerCmd(t *testing.T) {
+	want := "docker run --gpus -v home/job-dir:/inputs -v home/job-dir/outputs:/outputs mycontainer -- /bin/bash -c 'python -m molbind'"
+	got := InstructionToDockerCmd("mycontainer", "python -m molbind", "home/job-dir", true)
+	if want != got {
+		t.Errorf("got = %s; wanted %s", fmt.Sprint(got), fmt.Sprint(want))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 	appConfigsFilePath := flag.String("app-configs", "config/app.jsonl", "App Configurations file")
 	layers := flag.Int("layers", 2, "Number of layers to search in the directory path")
 	memory := flag.Int("memory", 0, "Memory for job in GB, 0 autopicks a value")
+	local := flag.Bool("local", false, "Use Docker on local machine to run job instead of Bacalhau")
 	dry := flag.Bool("dry", false, "Do not send request and just print Bacalhau cmd")
 	gpu := flag.Bool("gpu", false, "Use GPU")
 	network := flag.Bool("network", false, "All http requests during job runtime")
@@ -41,5 +42,5 @@ func main() {
 	fmt.Println("Using app configs:", *appConfigsFilePath)
 	fmt.Println("Setting layers to:", *layers)
 
-	plex.Execute(*app, *inputDir, *appConfigsFilePath, *layers, *memory, *gpu, *network, *dry)
+	plex.Execute(*app, *inputDir, *appConfigsFilePath, *layers, *memory, *local, *gpu, *network, *dry)
 }


### PR DESCRIPTION
This PR prints the Docker cmd if `local=true` is added as a flag. 

Future PR can add the ability to run the docker command automatically instead of printing it.

This also moved the CID creation out of the create instruction function. This is a step towards passing in CIDs without having the files locally.

example:

```./plex -app equibind -input-dir ./testdata/binding/pdbbind_processed_size1/ -local=true```

