### PR TITLE
add optional memory to tool config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -152,4 +152,4 @@ echo "3. [Linux only] If you recieve a warning about download speeds on Linux yo
 echo "sudo sysctl -w net.core.rmem_max=2500000"
 
 echo "After these steps, you're ready to generate computational biology data! Run the following command to run Equibind on test data:"
-echo "./plex -app equibind -input-dir ./testdata/binding/pdbbind_processed_size1/"
+echo "./plex -tool equibind -input-dir testdata/binding/abl"

--- a/internal/ipwl/ipwl.go
+++ b/internal/ipwl/ipwl.go
@@ -128,7 +128,15 @@ func processIOTask(ioEntry IO, index int, jobDir, ioJsonPath string, verbose, lo
 			fmt.Printf("Generated cmd: %s\n", cmd)
 		}
 
-		bacalhauJob, err := bacalhau.CreateBacalhauJob(cid, toolConfig.DockerPull, cmd, 12, toolConfig.GpuBool, toolConfig.NetworkBool)
+		// this memory type conversion is for backwards compatibility with the -app flag
+		var memory int
+		if toolConfig.MemoryGB == nil {
+			memory = 0
+		} else {
+			memory = *toolConfig.MemoryGB
+		}
+
+		bacalhauJob, err := bacalhau.CreateBacalhauJob(cid, toolConfig.DockerPull, cmd, memory, toolConfig.GpuBool, toolConfig.NetworkBool)
 		if err != nil {
 			updateIOWithError(ioJsonPath, index, err, fileMutex)
 			return fmt.Errorf("error creating Bacalhau job: %w", err)

--- a/internal/ipwl/tool.go
+++ b/internal/ipwl/tool.go
@@ -29,6 +29,7 @@ type Tool struct {
 	Arguments   []string              `json:"arguments"`
 	DockerPull  string                `json:"dockerPull"`
 	GpuBool     bool                  `json:"gpuBool"`
+	MemoryGB    *int                  `json:"memoryGB"`
 	NetworkBool bool                  `json:"networkBool"`
 	Inputs      map[string]ToolInput  `json:"inputs"`
 	Outputs     map[string]ToolOutput `json:"outputs"`

--- a/tools/colabfold-large.json
+++ b/tools/colabfold-large.json
@@ -9,6 +9,7 @@
     "dockerPull": "public.ecr.aws/p7l9w5o7/colabfold:latest",
     "gpuBool": true,
     "networkBool": true,
+    "memoryGB": 12,
     "inputs": {
       "sequence": {
         "type": "File",
@@ -34,4 +35,3 @@
       }
     }
 }
-  

--- a/tools/colabfold-standard.json
+++ b/tools/colabfold-standard.json
@@ -9,6 +9,7 @@
     "dockerPull": "public.ecr.aws/p7l9w5o7/colabfold:latest",
     "gpuBool": true,
     "networkBool": true,
+    "memoryGB": 12,
     "inputs": {
       "sequence": {
         "type": "File",

--- a/tools/diffdock.json
+++ b/tools/diffdock.json
@@ -12,6 +12,7 @@
     "dockerPull": "ghcr.io/labdao/diffdock:main@sha256:b00432de73478d3da578e4a16ee669178828109f3c7bf9c58d44bb7514f68629",
     "gpuBool": true,
     "networkBool": true,
+    "memoryGB": 12,
     "inputs": {
       "protein": {
         "type": "File",


### PR DESCRIPTION
I checked that diffdock and equibind still worked.