### PR TITLE
Adds a plex path option to allow the plex binary to be in a system path

### DIFF
--- a/python/plex/sdk.py
+++ b/python/plex/sdk.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 from typing import Dict, List, Union
 
 
-def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=False, retry=False, plexPath="./plex"):
+def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=False, retry=False, plex_path="./plex"):
     if not (isinstance(io, dict) or (isinstance(io, list) and all(isinstance(i, dict) for i in io))):
         raise ValueError('io must be a dict or a list of dicts')
 
@@ -23,7 +23,7 @@ def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=Fa
 
         cwd = os.getcwd()
         plex_work_dir = os.environ.get("PLEX_WORK_DIR",os.path.dirname(os.path.dirname(cwd)))
-        cmd = [plexPath, "-input-io", json_file_path, "-concurrency", str(concurrency)]
+        cmd = [plex_path, "-input-io", json_file_path, "-concurrency", str(concurrency)]
 
         if local:
             cmd.append("-local=true")

--- a/python/plex/sdk.py
+++ b/python/plex/sdk.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 from typing import Dict, List, Union
 
 
-def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=False, retry=False):
+def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=False, retry=False, plexPath="./plex"):
     if not (isinstance(io, dict) or (isinstance(io, list) and all(isinstance(i, dict) for i in io))):
         raise ValueError('io must be a dict or a list of dicts')
 
@@ -23,7 +23,7 @@ def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=Fa
 
         cwd = os.getcwd()
         plex_dir = os.path.dirname(os.path.dirname(cwd))
-        cmd = ["./plex", "-input-io", json_file_path, "-concurrency", str(concurrency)]
+        cmd = [plexPath, "-input-io", json_file_path, "-concurrency", str(concurrency)]
 
         if local:
             cmd.append("-local=true")

--- a/python/plex/sdk.py
+++ b/python/plex/sdk.py
@@ -22,7 +22,7 @@ def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=Fa
             json.dump(io, json_file, indent=4)
 
         cwd = os.getcwd()
-        plex_dir = os.path.dirname(os.path.dirname(cwd))
+        plex_work_dir = os.environ.get("PLEX_WORK_DIR",os.path.dirname(os.path.dirname(cwd)))
         cmd = [plexPath, "-input-io", json_file_path, "-concurrency", str(concurrency)]
 
         if local:
@@ -34,7 +34,7 @@ def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=Fa
         if retry:
             cmd.append("-retry=true")
 
-        with subprocess.Popen(cmd, stdout=subprocess.PIPE, bufsize=1, universal_newlines=True, cwd=plex_dir) as p:
+        with subprocess.Popen(cmd, stdout=subprocess.PIPE, bufsize=1, universal_newlines=True, cwd=plex_work_dir) as p:
             for line in p.stdout:
                 if "Initialized IO file at:" in line:
                     parts = line.split()


### PR DESCRIPTION
Allows a plexPath to be handed to the `run_plex` function in the python sdk. This will set us do 

```
run_plex(io_graph, plexPath="plex")
```
in notebooks on the labdao jupyter server, and allows us to keep all existing examples the same.

This is necessary since the plex binary does not live in the users home directory in our case.