### PR TITLE
Ansible for Plex compute node

### DIFF
--- a/infrastructure/ansible/files/bacalhau.service
+++ b/infrastructure/ansible/files/bacalhau.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Bacalhau
+
+[Service]
+User=ubuntu
+Group=ubuntu
+ExecStart=bacalhau serve \
+  --node-type compute,requester \
+  --ipfs-connect {{ ipfs_connect }} \
+  --private-internal-ipfs=false \
+  --limit-total-gpu 1 \
+  --limit-job-memory 12gb \
+  --job-selection-accept-networked \
+  --job-selection-data-locality anywhere \
+  --labels owner={{ owner }}
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/ansible/files/ipfs.service
+++ b/infrastructure/ansible/files/ipfs.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=IPFS daemon
+
+[Service]
+User=ubuntu
+Group=ubuntu
+ExecStart=ipfs daemon --routing=dhtclient
+Environment="IPFS_PATH=/opt/local/ipfs"
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/ansible/provision_compute_instance.yaml
+++ b/infrastructure/ansible/provision_compute_instance.yaml
@@ -156,11 +156,39 @@
       ansible.builtin.copy:
         src: files/ipfs.service
         dest: /etc/systemd/system
+      notify:
+        - Systemd Daemon Reload
 
     - name: Enable and start the IPFS Daemon
       become: yes
-      ansible.builtin.systemd:
+      ansible.builtin.service:
         name: ipfs
+        state: started
+        enabled: true
+
+    - name: Install Bacalhau
+      ansible.builtin.shell:
+        cmd: curl -sL https://get.bacalhau.org/install.sh | bash
+
+    - name: Bump System Resources
+      become: yes
+      ansible.builtin.command: sysctl -w net.core.rmem_max=2500000
+
+    - name: Install the Bacalhau systemd unit
+      become: yes
+      ansible.builtin.template:
+        src: files/bacalhau.service
+        dest: /etc/systemd/system
+      vars:
+        owner: labdao
+        ipfs_connect: /ip4/127.0.0.1/tcp/5001
+      notify:
+        - Systemd Daemon Reload
+
+    - name: Enable and start Bacalhau
+      become: yes
+      ansible.builtin.service:
+        name: bacalhau
         state: started
         enabled: true
 
@@ -170,3 +198,8 @@
       ansible.builtin.service:
         name: docker
         state: restarted
+
+    - name: Systemd Daemon Reload
+      become: yes
+      ansible.builtin.systemd:
+        daemon_reload: true

--- a/infrastructure/ansible/provision_compute_instance.yaml
+++ b/infrastructure/ansible/provision_compute_instance.yaml
@@ -1,0 +1,171 @@
+- name: Provisition Plex
+  remote_user: ubuntu
+  hosts: tag_Type_compute
+  vars:
+    nvidia_distribution: ubuntu2004
+    nvidia_container_toolkit_key_path: /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+    ipfs_path: /opt/local/ipfs
+  environment:
+    IPFS_PATH: "{{ ipfs_path }}"
+  tasks:
+    # Aptitude is preferred by ansible
+    - name: Install aptitude
+      become: yes
+      ansible.builtin.apt:
+        name: aptitude
+        state: latest
+        update_cache: true
+
+    # Docker
+    - name: Add Docker GPG key
+      become: yes
+      ansible.builtin.get_url:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        dest: /etc/apt/trusted.gpg.d/docker.asc
+
+    - name: Add Docker Repository
+      become: yes
+      ansible.builtin.apt_repository:
+        repo: deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
+        state: present
+
+    - name: Create the docker group
+      become: yes
+      ansible.builtin.group:
+        name: docker
+
+    - name: Add ubuntu user to docker group
+      become: yes
+      ansible.builtin.user:
+        name: ubuntu
+        groups: docker
+
+    # Nvidia
+    - name: Get Nvidia drivers apt key
+      ansible.builtin.get_url:
+        url: https://developer.download.nvidia.com/compute/cuda/repos/{{ nvidia_distribution }}/x86_64/cuda-keyring_1.0-1_all.deb
+        dest: /tmp/cuda-keyring.deb
+
+    - name: Add Nvidia Keyring
+      become: yes
+      ansible.builtin.apt:
+        deb: /tmp/cuda-keyring.deb
+          
+    - name: Get Nvidia Container Tookit GPG key
+      become: yes
+      ansible.builtin.shell:
+        cmd: curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --yes --dearmor -o {{ nvidia_container_toolkit_key_path }}
+        creates: "{{ nvidia_container_toolkit_key_path }}"
+ 
+    - name: Add Nvidia Container Tookit Repository
+      become: yes
+      ansible.builtin.apt_repository:
+        repo: deb [signed-by={{ nvidia_container_toolkit_key_path }}] https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/$(ARCH) /
+        state: present
+
+    - name: Install required system packages
+      become: yes
+      ansible.builtin.apt:
+        pkg:
+          - ca-certificates
+          - curl
+          - gnupg
+          - lsb-release
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-compose-plugin
+          - cuda-drivers
+        state: latest
+        update_cache: true
+
+    - name: Install Nvidia Container Tookit
+      become: yes
+      ansible.builtin.apt:
+        pkg:
+          - nvidia-docker2
+      notify:
+        - Restart docker
+
+    - name: Ensure Nvidia persitence daemon is started
+      ansible.builtin.systemd:
+        name: nvidia-persistenced
+
+    - name: Install Golag
+      become: yes
+      vars:
+        go_version: 1.20.3
+      block:
+        - name: Download Go binary
+          ansible.builtin.get_url:
+            url: https://go.dev/dl/go{{ go_version }}.linux-amd64.tar.gz
+            dest: /tmp/go-binary.tar.gz
+        - name: Unzip Go binary
+          ansible.builtin.command:
+            cmd: tar -C /usr/local -xzf /tmp/go-binary.tar.gz
+
+    - name: Install IPFS
+      ansible.builtin.get_url:
+        url: https://dist.ipfs.tech/kubo/v0.18.0/kubo_v0.18.0_linux-amd64.tar.gz
+        dest: /tmp/ipfs.tar.gz  
+    
+    - name: Make a folder to put IPFS files in
+      ansible.builtin.file:
+        path: /tmp/ipfs
+        state: directory
+
+    - name: Unzip IPFS
+      become: yes
+      ansible.builtin.unarchive:
+        remote_src: true
+        src: /tmp/ipfs.tar.gz
+        dest: /tmp/ipfs
+
+    - name: Install Kubo
+      become: yes
+      ansible.builtin.command: /tmp/ipfs/kubo/install.sh
+
+    - name: Create IPFS directory
+      become: yes
+      ansible.builtin.file:
+        owner: ubuntu
+        group: ubuntu
+        path: /opt/local/ipfs
+        state: directory
+
+    - name: Put the IPFS directory in env for future shells
+      become: yes
+      ansible.builtin.lineinfile:
+        path: /etc/environment
+        line: IPFS_PATH={{ ipfs_path }}
+
+    - name: Initiazlie IPFS
+      ansible.builtin.command:
+        cmd: ipfs init
+        creates: "{{ ipfs_path }}/config"
+
+    - name: Configure IPFS
+      ansible.builtin.shell: |
+        ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
+        ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
+        ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST"]'
+        ipfs config Pinning.Recursive true
+
+    - name: Install the IPFS systemd unit
+      become: yes
+      ansible.builtin.copy:
+        src: files/ipfs.service
+        dest: /etc/systemd/system
+
+    - name: Enable and start the IPFS Daemon
+      become: yes
+      ansible.builtin.systemd:
+        name: ipfs
+        state: started
+        enabled: true
+
+  handlers:
+    - name: Restart docker
+      ansible.builtin.service:
+        name: docker
+        state: restarted

--- a/infrastructure/ansible/provision_compute_instance.yaml
+++ b/infrastructure/ansible/provision_compute_instance.yaml
@@ -166,6 +166,7 @@
 
   handlers:
     - name: Restart docker
+      become: yes
       ansible.builtin.service:
         name: docker
         state: restarted

--- a/infrastructure/terraform/plex.tf
+++ b/infrastructure/terraform/plex.tf
@@ -18,6 +18,30 @@ resource "aws_instance" "plex_prod" {
   }
 }
 
+resource "aws_instance" "ops_test" {
+  for_each      = toset(["opstest"])
+  ami           = var.ami_main
+  instance_type = "g5.xlarge"
+
+  vpc_security_group_ids = [aws_security_group.plex.id]
+  key_name               = var.key_main
+  availability_zone      = var.availability_zones[0]
+
+  root_block_device {
+    volume_size = 1000
+    tags = {
+      Name = "plex-prod"
+    }
+  }
+
+  tags = {
+    Name        = "plex-prod-${each.key}"
+    InstanceKey = each.key
+    Type        = "compute"
+  }
+}
+
+
 resource "aws_eip" "plex_prod" {
   instance = aws_instance.plex_prod.id
   vpc      = true

--- a/infrastructure/terraform/plex.tf
+++ b/infrastructure/terraform/plex.tf
@@ -19,8 +19,8 @@ resource "aws_instance" "plex_prod" {
 }
 
 resource "aws_instance" "ops_test" {
-  for_each      = toset(["opstest"])
-  ami           = var.ami_main
+  for_each      = toset([])
+  ami           = "ami-053b0d53c279acc90"
   instance_type = "g5.xlarge"
 
   vpc_security_group_ids = [aws_security_group.plex.id]


### PR DESCRIPTION
Achieves basically what the current provide-compute.sh script does in Ansible. With the following differences:
* Does not set up jupyter
* Moves ipfs and bacalhau to systemd processes
* Moves ipfs location to /opt/local (easier to split into a separate EBS volume later)