### PR TITLE
Promote new compute node

### DIFF
--- a/infrastructure/terraform/plex.tf
+++ b/infrastructure/terraform/plex.tf
@@ -18,10 +18,10 @@ resource "aws_instance" "plex_prod" {
   }
 }
 
-resource "aws_instance" "ops_test" {
-  for_each      = toset([])
+resource "aws_instance" "plex_compute_prod" {
+  for_each      = toset(["compute1"])
   ami           = "ami-053b0d53c279acc90"
-  instance_type = "g5.xlarge"
+  instance_type = "g5.2xlarge"
 
   vpc_security_group_ids = [aws_security_group.plex.id]
   key_name               = var.key_main
@@ -30,7 +30,7 @@ resource "aws_instance" "ops_test" {
   root_block_device {
     volume_size = 1000
     tags = {
-      Name = "plex-prod"
+      Name = "plex-prod-${each.key}"
     }
   }
 
@@ -43,7 +43,7 @@ resource "aws_instance" "ops_test" {
 
 
 resource "aws_eip" "plex_prod" {
-  instance = aws_instance.plex_prod.id
+  instance = aws_instance.plex_compute_prod["compute1"].id
   vpc      = true
 
   tags = {


### PR DESCRIPTION
Promotes the new compute node to prod by bouncing the existing elastic ip to the new instance.