### PR TITLE
make sapling animate optional

### DIFF
--- a/cmd/plex/cli.go
+++ b/cmd/plex/cli.go
@@ -12,7 +12,7 @@ import (
 	"github.com/labdao/plex/internal/web3"
 )
 
-func Run(toolPath, inputDir, ioJsonPath, workDir string, verbose, retry, local bool, concurrency, layers int, web3 bool) {
+func Run(toolPath, inputDir, ioJsonPath, workDir string, verbose, retry, local, showAnimation bool, concurrency, layers int, web3 bool) {
 	// mint an NFT if web3 flag is set
 	// ./plex -tool equibind -input-io /some/path/to/io.json -web3=true
 	if web3 {
@@ -88,7 +88,7 @@ func Run(toolPath, inputDir, ioJsonPath, workDir string, verbose, retry, local b
 	fmt.Println("Processing IO Entries")
 	fmt.Println(workDirPath)
 	fmt.Println(ioJsonPath)
-	ipwl.ProcessIOList(workDirPath, ioJsonPath, retry, verbose, local, concurrency)
+	ipwl.ProcessIOList(workDirPath, ioJsonPath, retry, verbose, local, showAnimation, concurrency)
 	fmt.Printf("Finished processing, results written to %s\n", ioJsonPath)
 	// if web3 {
 	// 	mintNFT(toolPath, ioJsonPath)

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -97,8 +97,8 @@ func GetBacalhauJobResults(submittedJob *model.Job, showAnimation bool) (results
 			animation[saplingIndex] = "\U0001F331"
 			fmt.Printf("////%s////\r", strings.Join(animation, ""))
 			animation[saplingIndex] = "_"
-			time.Sleep(2 * time.Second)
 		}
+		time.Sleep(2 * time.Second)
 	}
 	return results, err
 }

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -83,22 +83,22 @@ func GetBacalhauJobResults(submittedJob *model.Job, showAnimation bool) (results
 	fmt.Println("Job running...")
 
 	fmt.Printf("Bacalhau job id: %s \n", submittedJob.Metadata.ID)
-	if showAnimation {
-		for i := 0; i < maxTrys; i++ {
+
+	for i := 0; i < maxTrys; i++ {
+		if showAnimation {
 			saplingIndex := i % 5
-
-			results, err = client.GetResults(context.Background(), submittedJob.Metadata.ID)
-			if err != nil {
-				return results, err
-			}
-			if len(results) > 0 {
-				return results, err
-			}
-
 			animation[saplingIndex] = "\U0001F331"
 			fmt.Printf("////%s////\r", strings.Join(animation, ""))
 			animation[saplingIndex] = "_"
 			time.Sleep(2 * time.Second)
+		}
+
+		results, err = client.GetResults(context.Background(), submittedJob.Metadata.ID)
+		if err != nil {
+			return results, err
+		}
+		if len(results) > 0 {
+			return results, err
 		}
 	}
 	return results, err

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -85,20 +85,19 @@ func GetBacalhauJobResults(submittedJob *model.Job, showAnimation bool) (results
 	fmt.Printf("Bacalhau job id: %s \n", submittedJob.Metadata.ID)
 
 	for i := 0; i < maxTrys; i++ {
-		if showAnimation {
-			saplingIndex := i % 5
-			animation[saplingIndex] = "\U0001F331"
-			fmt.Printf("////%s////\r", strings.Join(animation, ""))
-			animation[saplingIndex] = "_"
-			time.Sleep(2 * time.Second)
-		}
-
 		results, err = client.GetResults(context.Background(), submittedJob.Metadata.ID)
 		if err != nil {
 			return results, err
 		}
 		if len(results) > 0 {
 			return results, err
+		}
+		if showAnimation {
+			saplingIndex := i % 5
+			animation[saplingIndex] = "\U0001F331"
+			fmt.Printf("////%s////\r", strings.Join(animation, ""))
+			animation[saplingIndex] = "_"
+			time.Sleep(2 * time.Second)
 		}
 	}
 	return results, err

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -76,28 +76,30 @@ func SubmitBacalhauJob(job *model.Job) (submittedJob *model.Job, err error) {
 	return submittedJob, err
 }
 
-func GetBacalhauJobResults(submittedJob *model.Job) (results []model.PublishedResult, err error) {
+func GetBacalhauJobResults(submittedJob *model.Job, showAnimation bool) (results []model.PublishedResult, err error) {
 	client := CreateBacalhauClient()
 	maxTrys := 360 // 30 minutes divided by 5 seconds is 360 iterations
 	animation := []string{"\U0001F331", "_", "_", "_", "_"}
 	fmt.Println("Job running...")
 
 	fmt.Printf("Bacalhau job id: %s \n", submittedJob.Metadata.ID)
-	for i := 0; i < maxTrys; i++ {
-		saplingIndex := i % 5
+	if showAnimation {
+		for i := 0; i < maxTrys; i++ {
+			saplingIndex := i % 5
 
-		results, err = client.GetResults(context.Background(), submittedJob.Metadata.ID)
-		if err != nil {
-			return results, err
-		}
-		if len(results) > 0 {
-			return results, err
-		}
+			results, err = client.GetResults(context.Background(), submittedJob.Metadata.ID)
+			if err != nil {
+				return results, err
+			}
+			if len(results) > 0 {
+				return results, err
+			}
 
-		animation[saplingIndex] = "\U0001F331"
-		fmt.Printf("////%s////\r", strings.Join(animation, ""))
-		animation[saplingIndex] = "_"
-		time.Sleep(2 * time.Second)
+			animation[saplingIndex] = "\U0001F331"
+			fmt.Printf("////%s////\r", strings.Join(animation, ""))
+			animation[saplingIndex] = "_"
+			time.Sleep(2 * time.Second)
+		}
 	}
 	return results, err
 }

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 	layers := flag.Int("layers", 2, "Number of layers to search in the directory path")
 	concurrency := flag.Int("concurrency", 1, "How many IO entries to run at once")
 	local := flag.Bool("local", false, "Use Docker on local machine to run job instead of Bacalhau")
+	showAnimation := flag.Bool("show-animation", true, "Show animation while Bacalhau job is running")
 	retry := flag.Bool("retry", false, "Retry any io subgraphs that failed")
 
 	web3 := flag.Bool("web3", false, "Option to mint an NFT")
@@ -55,13 +56,13 @@ func main() {
 			os.Exit(1)
 		}
 		*retry = false // can only retry from an PLEx work dir not input directory input
-		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *verbose, *retry, *local, *concurrency, *layers, *web3)
+		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *verbose, *retry, *local, *showAnimation, *concurrency, *layers, *web3)
 	} else if *ioJsonPath != "" {
 		fmt.Println("Running IPWL io path")
 		*retry = false // can only retry from an PLEx work dir not io json path input
-		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *verbose, *retry, *local, *concurrency, *layers, *web3)
+		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *verbose, *retry, *local, *showAnimation, *concurrency, *layers, *web3)
 	} else if *workDir != "" {
-		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *verbose, *retry, *local, *concurrency, *layers, *web3)
+		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *verbose, *retry, *local, *showAnimation, *concurrency, *layers, *web3)
 	} else {
 		fmt.Println("Requirements invalid. Please run './plex -h' for help.")
 	}

--- a/python/plex/sdk.py
+++ b/python/plex/sdk.py
@@ -53,7 +53,7 @@ def generate_io_graph_from_tool(tool_filepath, scattering_method=ScatteringMetho
     
     return io_json_graph
 
-def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=False, retry=False, plex_path="./plex"):
+def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=False, retry=False, showAnimation=False, plex_path="./plex"):
     if not (isinstance(io, dict) or (isinstance(io, list) and all(isinstance(i, dict) for i in io))):
         raise ValueError('io must be a dict or a list of dicts')
 
@@ -80,6 +80,9 @@ def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=Fa
 
         if retry:
             cmd.append("-retry=true")
+
+        if not showAnimation: # default is true in the CLI
+            cmd.append("-show-animation=false")
 
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, bufsize=1, universal_newlines=True, cwd=plex_work_dir) as p:
             for line in p.stdout:


### PR DESCRIPTION
Add's a `-show-animation` flag to plex to toggle sappling emoji which doesn't not look good in the notebook.

Default in CLI
<img width="1129" alt="Screenshot 2023-05-31 at 11 11 35 AM" src="https://github.com/labdao/plex/assets/9427089/f34426ce-3af4-4fbb-97dc-df7151b9637b">

Set to false in CLI
<img width="1268" alt="Screenshot 2023-05-31 at 11 11 55 AM" src="https://github.com/labdao/plex/assets/9427089/423d0b28-4323-4fb2-a033-12e266e167ab">


