### PR TITLE
Canary simple canary on GH actions

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+dotenv_if_exists

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-dotenv_if_exists

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -18,20 +18,22 @@ jobs:
 
       - name: Download the latest release
         run: |
-          echo $(gh release --repo labdao/plex list | grep Latest | cut -f1)
+          # echo $(gh release --repo labdao/plex list | grep Latest | cut -f1)
           # use the GitHub CLI to download the latest release
           gh release download --repo labdao/plex --pattern "*linux_amd64.tar.gz"
+          # extract the package
+          tar -xf *.tar.gz
 
-      # - name: Run Equibind
-      #   run: |
-      #     result_dir=$(./plex -tool equibind -input-dir testdata/binding/abl | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
-      #     cd "$result_dir/entry-0/outputs"
-      #     if [ "$(find . -name '*docked.sdf' | grep 'docked.sdf')" == "" ]; then
-      #       echo "No docked files found"
-      #       exit 1
-      #     else
-      #       echo "Docked files found:"
-      #       find . -name '*docked.sdf' | grep 'docked.sdf'
-      #     fi
-      #   env:
-      #     PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
+      - name: Run Equibind
+        run: |
+          result_dir=$(./plex -tool equibind -input-dir testdata/binding/abl | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
+          cd "$result_dir/entry-0/outputs"
+          if [ "$(find . -name '*docked.sdf' | grep 'docked.sdf')" == "" ]; then
+            echo "No docked files found"
+            exit 1
+          else
+            echo "Docked files found:"
+            find . -name '*docked.sdf' | grep 'docked.sdf'
+          fi
+        env:
+          PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -12,6 +12,8 @@ jobs:
   canary:
     runs-on: ubuntu-20.04
     environment: releaser
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
 
       - name: Download the latest release

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -18,9 +18,9 @@ jobs:
 
       - name: Download the latest release
         run: |
-          echo $(gh release list | grep Latest | cut -f1)
+          echo $(gh release --repo labdao/plex list | grep Latest | cut -f1)
           # use the GitHub CLI to download the latest release
-          gh release download --pattern "*linux_amd64.tar.gz"
+          gh release download --repo labdao/plex --pattern "*linux_amd64.tar.gz"
 
       # - name: Run Equibind
       #   run: |

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,7 +1,7 @@
 name: Canary Run Equibind Tool
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
   push:
     branches:
       - 'ops/**'
@@ -44,4 +44,5 @@ jobs:
 
 
       - name: Check in with Heii On-Call
-        run: curl -X POST -H 'Authorization: Bearer heii_l5iNt7vLIXmiULchN9O5jI034zMwUKS5m5OnCczXCPwRiVGb_7ede0fe1' https://api.heiioncall.com./triggers/${HEII_ON_CALL_INBOUND_TRIGGER_ID}/checkin
+        run: |
+          curl -X POST -H 'Authorization: Bearer heii_l5iNt7vLIXmiULchN9O5jI034zMwUKS5m5OnCczXCPwRiVGb_7ede0fe1' https://api.heiioncall.com./triggers/${HEII_ON_CALL_INBOUND_TRIGGER_ID}/checkin

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Run Equibind
         run: |
-          echo ${{ secrets.PLEX_ACCESS_TOKEN }}
           ./plex -tool equibind -input-dir testdata/binding/abl
           # result_dir=$(./plex -tool equibind -input-dir testdata/binding/abl | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
           # echo "Changing directory to $result_dir"
@@ -43,7 +42,8 @@ jobs:
           #   find . -name '*docked.sdf' | grep 'docked.sdf'
           # fi
         env:
-          PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
+          # PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
+          PLEX_ACCESS_TOKEN: mellon 
 
       - name: Check in with Heii On-Call
         run: |

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Run Equibind
         run: |
+          echo ${{ secrets.PLEX_ACCESS_TOKEN }}
           ./plex -tool equibind -input-dir testdata/binding/abl
           # result_dir=$(./plex -tool equibind -input-dir testdata/binding/abl | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
           # echo "Changing directory to $result_dir"
@@ -43,7 +44,6 @@ jobs:
           # fi
         env:
           PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
-
 
       - name: Check in with Heii On-Call
         run: |

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -30,16 +30,17 @@ jobs:
 
       - name: Run Equibind
         run: |
-          result_dir=$(./plex -tool equibind -input-dir testdata/binding/abl | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
-          echo "Changing directory to $result_dir"
-          cd "$result_dir/entry-0/outputs"
-          if [ "$(find . -name '*docked.sdf' | grep 'docked.sdf')" == "" ]; then
-            echo "No docked files found"
-            exit 1
-          else
-            echo "Docked files found:"
-            find . -name '*docked.sdf' | grep 'docked.sdf'
-          fi
+          ./plex -tool equibind -input-dir testdata/binding/abl
+          # result_dir=$(./plex -tool equibind -input-dir testdata/binding/abl | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
+          # echo "Changing directory to $result_dir"
+          # cd "$result_dir/entry-0/outputs"
+          # if [ "$(find . -name '*docked.sdf' | grep 'docked.sdf')" == "" ]; then
+          #   echo "No docked files found"
+          #   exit 1
+          # else
+          #   echo "Docked files found:"
+          #   find . -name '*docked.sdf' | grep 'docked.sdf'
+          # fi
         env:
           PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
 

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -29,17 +29,20 @@ jobs:
 
       - name: Run Equibind
         run: |
-          ./plex -tool equibind -input-dir testdata/binding/abl
-          # result_dir=$(./plex -tool equibind -input-dir testdata/binding/abl | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
-          # echo "Changing directory to $result_dir"
-          # cd "$result_dir/entry-0/outputs"
-          # if [ "$(find . -name '*docked.sdf' | grep 'docked.sdf')" == "" ]; then
-          #   echo "No docked files found"
-          #   exit 1
-          # else
-          #   echo "Docked files found:"
-          #   find . -name '*docked.sdf' | grep 'docked.sdf'
-          # fi
+          ./plex -tool equibind -input-dir testdata/binding/abl 2>&1 | tee plex_out.log
+          plex_result_code=${PIPESTATUS[0]}
+          if [ $plex_result_code -gt 0 ] then
+            # exit immediately if plex exited with an error
+            exit $plex_result_code
+          fi
+          result_dir=$(cat plex_out.log | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
+          cd "$result_dir/entry-0/outputs"
+          if [ "$(find . -name '*docked.sdf' | grep 'docked.sdf')" == "" ]; then
+            echo "No docked files found"
+            exit 1
+          else
+            echo "Docked files found"
+          fi
         env:
           # PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
           PLEX_ACCESS_TOKEN: mellon 

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -2,6 +2,9 @@ name: Canary Run Equibind Tool
 
 on:
   workflow_dispatch: {}
+  push:
+    branches:
+      - 'ops/**'
   # schedule:
   #  - cron: '*/10 * * * *'
 

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Run Equibind
         run: |
           result_dir=$(./plex -tool equibind -input-dir testdata/binding/abl | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
+          echo "Changing directory to $result_dir"
           cd "$result_dir/entry-0/outputs"
           if [ "$(find . -name '*docked.sdf' | grep 'docked.sdf')" == "" ]; then
             echo "No docked files found"

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   canary:
     runs-on: ubuntu-20.04
-    environment: test
+    environment: ci
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -31,7 +31,7 @@ jobs:
         run: |
           ./plex -tool equibind -input-dir testdata/binding/abl 2>&1 | tee plex_out.log
           plex_result_code=${PIPESTATUS[0]}
-          if [ $plex_result_code -gt 0 ] then
+          if [ $plex_result_code -gt 0 ]; then
             # exit immediately if plex exited with an error
             exit $plex_result_code
           fi
@@ -44,11 +44,10 @@ jobs:
             echo "Docked files found"
           fi
         env:
-          # PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
-          PLEX_ACCESS_TOKEN: mellon 
+          PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
 
       - name: Check in with Heii On-Call
         run: |
-          curl -X POST -H 'Authorization: Bearer heii_l5iNt7vLIXmiULchN9O5jI034zMwUKS5m5OnCczXCPwRiVGb_7ede0fe1' https://api.heiioncall.com./triggers/${HEII_ON_CALL_INBOUND_TRIGGER_ID}/checkin
+          curl -X POST -H 'Authorization: Bearer ${{ secrets.HEII_ON_CALL_API_KEY }}' https://api.heiioncall.com./triggers/${HEII_ON_CALL_INBOUND_TRIGGER_ID}/checkin
         env:
           HEII_ON_CALL_INBOUND_TRIGGER_ID: e720588c-35cd-4392-9d02-bec350aa34e9

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -16,8 +16,9 @@ jobs:
 
       - name: Download the latest release
         run: |
-          latest_release=$(gh list releases | cut -f1)
-          echo latest_relase
+          echo $(gh release list | grep Latest | cut -f1)
+          # use the GitHub CLI to download the latest release
+          gh release download --pattern "*linux_amd64.tar.gz"
 
       # - name: Run Equibind
       #   run: |

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -16,6 +16,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
 
+      # Checkout the repository. Note we do not use anything other than the test data and tools directory
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Download the latest release
         run: |
           # echo $(gh release --repo labdao/plex list | grep Latest | cut -f1)

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -2,9 +2,6 @@ name: Canary Run Equibind Tool
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - 'ops/**'
   schedule:
     - cron: '*/10 * * * *'
 

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -41,7 +41,7 @@ jobs:
           #   echo "Docked files found:"
           #   find . -name '*docked.sdf' | grep 'docked.sdf'
           # fi
-        env:
+        # env:
           # PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
           # PLEX_ACCESS_TOKEN: mellon 
 

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,6 @@ jobs:
     environment: test
     env:
       GH_TOKEN: ${{ github.token }}
-      HEII_ON_CALL_INBOUND_TRIGGER_ID: e720588c-35cd-4392-9d02-bec350aa34e9
     steps:
       # Checkout the repository. Note we do not use anything other than the test data and tools directory
       - name: Checkout
@@ -30,6 +29,7 @@ jobs:
 
       - name: Run Equibind
         run: |
+          export PLEX_ACCESS_TOKEN=${{ secrets.PLEX_ACCESS_TOKEN }}
           ./plex -tool equibind -input-dir testdata/binding/abl
           # result_dir=$(./plex -tool equibind -input-dir testdata/binding/abl | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
           # echo "Changing directory to $result_dir"
@@ -43,8 +43,10 @@ jobs:
           # fi
         env:
           # PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
-          PLEX_ACCESS_TOKEN: mellon 
+          # PLEX_ACCESS_TOKEN: mellon 
 
       - name: Check in with Heii On-Call
         run: |
           curl -X POST -H 'Authorization: Bearer heii_l5iNt7vLIXmiULchN9O5jI034zMwUKS5m5OnCczXCPwRiVGb_7ede0fe1' https://api.heiioncall.com./triggers/${HEII_ON_CALL_INBOUND_TRIGGER_ID}/checkin
+        env:
+          HEII_ON_CALL_INBOUND_TRIGGER_ID: e720588c-35cd-4392-9d02-bec350aa34e9

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -29,7 +29,6 @@ jobs:
 
       - name: Run Equibind
         run: |
-          export PLEX_ACCESS_TOKEN=${{ secrets.PLEX_ACCESS_TOKEN }}
           ./plex -tool equibind -input-dir testdata/binding/abl
           # result_dir=$(./plex -tool equibind -input-dir testdata/binding/abl | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
           # echo "Changing directory to $result_dir"
@@ -41,9 +40,9 @@ jobs:
           #   echo "Docked files found:"
           #   find . -name '*docked.sdf' | grep 'docked.sdf'
           # fi
-        # env:
+        env:
           # PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
-          # PLEX_ACCESS_TOKEN: mellon 
+          PLEX_ACCESS_TOKEN: mellon 
 
       - name: Check in with Heii On-Call
         run: |

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -5,8 +5,8 @@ on:
   push:
     branches:
       - 'ops/**'
-  # schedule:
-  #  - cron: '*/10 * * * *'
+  schedule:
+    - cron: '*/10 * * * *'
 
 jobs:
   canary:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -18,7 +18,6 @@ jobs:
 
       - name: Download the latest release
         run: |
-          # echo $(gh release --repo labdao/plex list | grep Latest | cut -f1)
           # use the GitHub CLI to download the latest release
           gh release download --repo labdao/plex --pattern "*linux_amd64.tar.gz"
           # extract the package
@@ -26,13 +25,17 @@ jobs:
 
       - name: Run Equibind
         run: |
+          # use tee so we can see stdout in github, and parse it later
           ./plex -tool equibind -input-dir testdata/binding/abl 2>&1 | tee plex_out.log
+          # capture the exit status of the plex call
           plex_result_code=${PIPESTATUS[0]}
+          # exit immediately if plex exited with an error
           if [ $plex_result_code -gt 0 ]; then
-            # exit immediately if plex exited with an error
             exit $plex_result_code
           fi
+          # parse the output directory from the plex stdout
           result_dir=$(cat plex_out.log | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
+          # exit if no docked files are found
           cd "$result_dir/entry-0/outputs"
           if [ "$(find . -name '*docked.sdf' | grep 'docked.sdf')" == "" ]; then
             echo "No docked files found"

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,31 @@
+name: Canary Run Equibind Tool
+
+on:
+  workflow_dispatch: {}
+  # schedule:
+  #  - cron: '*/10 * * * *'
+
+jobs:
+  canary:
+    runs-on: ubuntu-20.04
+    environment: releaser
+    steps:
+
+      - name: Download the latest release
+        run: |
+          latest_release=$(gh list releases | cut -f1)
+          echo latest_relase
+
+      # - name: Run Equibind
+      #   run: |
+      #     result_dir=$(./plex -tool equibind -input-dir testdata/binding/abl | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
+      #     cd "$result_dir/entry-0/outputs"
+      #     if [ "$(find . -name '*docked.sdf' | grep 'docked.sdf')" == "" ]; then
+      #       echo "No docked files found"
+      #       exit 1
+      #     else
+      #       echo "Docked files found:"
+      #       find . -name '*docked.sdf' | grep 'docked.sdf'
+      #     fi
+      #   env:
+      #     PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -11,11 +11,11 @@ on:
 jobs:
   canary:
     runs-on: ubuntu-20.04
-    environment: releaser
+    environment: test
     env:
       GH_TOKEN: ${{ github.token }}
+      HEII_ON_CALL_INBOUND_TRIGGER_ID: e720588c-35cd-4392-9d02-bec350aa34e9
     steps:
-
       # Checkout the repository. Note we do not use anything other than the test data and tools directory
       - name: Checkout
         uses: actions/checkout@v3
@@ -41,3 +41,7 @@ jobs:
           fi
         env:
           PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
+
+
+      - name: Check in with Heii On-Call
+        run: curl -X POST -H 'Authorization: Bearer heii_l5iNt7vLIXmiULchN9O5jI034zMwUKS5m5OnCczXCPwRiVGb_7ede0fe1' https://api.heiioncall.com./triggers/${HEII_ON_CALL_INBOUND_TRIGGER_ID}/checkin


### PR DESCRIPTION
First pass at a canary job that runs every 10 minutes on github actions. 

Each run seems to take about 1 minute which will be about 4000 minutes per month. Best I can tell public open source repos get infinite minutes, so as long as we don't get cut off this seems like a good start.

Currently this action checks in at the end of every run. The Heii On-Call trigger is then set to alert if nobody checks within 22 minutes, so two failed runs + a little buffer. A more nuanced version of this would involve retries, and possibly even restarting the compute node, but lets see how this does in production before we over complicate things.