### PR TITLE
modified install script to work for i386 darwin chips

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ downloadPlex() {
 
         if [ "$OS" = "darwin" ]
         then
-            if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x86_64" ]
+            if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "i386" ]
             then
                 curl -sSL https://github.com/labdao/plex/releases/download/$LATEST_RELEASE/plex_${RELEASE_WITHOUT_V}_darwin_amd64.tar.gz | tar xvz
             elif [ "$ARCH" = "arm64" ]


### PR DESCRIPTION
i386 chip was not checked as a conditional in the install script

tested on my i386 macbook and was able to download the darwin amd64 go release and run starter equibind command

```
saisamarth@Sais-MacBook-Air plex % ./plex -tool equibind -input-dir testdata/binding/abl
Plex version (v0.7.4) up to date.
toolPath tools/equibind.json
Running IPWL tool path
Warning: tool path support will be removed and moved to the Python SDK in the future
Created working directory:  /Users/saisamarth/Desktop/cide/test-plex/plex/cbbad351-d203-42b7-b1a2-e03055d1e6d1
Reading tool config:  tools/equibind.json
Creating IO Entries from input directory:  testdata/binding/abl
Initialized IO file at:  /Users/saisamarth/Desktop/cide/test-plex/plex/cbbad351-d203-42b7-b1a2-e03055d1e6d1/io.json
Processing IO Entries
/Users/saisamarth/Desktop/cide/test-plex/plex/cbbad351-d203-42b7-b1a2-e03055d1e6d1
/Users/saisamarth/Desktop/cide/test-plex/plex/cbbad351-d203-42b7-b1a2-e03055d1e6d1/io.json
Starting to process IO entry 1 
Job running...
Bacalhau job id: 22cefe4e-008c-43cb-aafa-7a4be1a5e6fb 
////_🌱___////
Computing default go-libp2p Resource Manager limits based on:
    - 'Swarm.ResourceMgr.MaxMemory': "4.3 GB"
    - 'Swarm.ResourceMgr.MaxFileDescriptors': 5120

Applying any user-supplied overrides on top.
Run 'ipfs swarm limit all' to see the resulting limits.

Success processing IO entry 1 
Starting to process IO entry 0 
Job running...
Bacalhau job id: 76466b74-91fa-4a7f-a563-7916140e7c54 
////_🌱___////
Computing default go-libp2p Resource Manager limits based on:
    - 'Swarm.ResourceMgr.MaxMemory': "4.3 GB"
    - 'Swarm.ResourceMgr.MaxFileDescriptors': 5120

Applying any user-supplied overrides on top.
Run 'ipfs swarm limit all' to see the resulting limits.

Success processing IO entry 0 
Finished processing, results written to /Users/saisamarth/Desktop/cide/test-plex/plex/cbbad351-d203-42b7-b1a2-e03055d1e6d1/io.json
```