### PR TITLE
Set file permissions umask in jupyter configuration

### DIFF
--- a/infrastructure/ansible/files/jupyter_notebook_config.py
+++ b/infrastructure/ansible/files/jupyter_notebook_config.py
@@ -1,0 +1,2 @@
+import os
+os.umask(0o002)

--- a/infrastructure/ansible/files/set_permissions.py
+++ b/infrastructure/ansible/files/set_permissions.py
@@ -1,0 +1,2 @@
+import os
+os.chmod(os_path,0o660)

--- a/infrastructure/ansible/files/set_permissions.py
+++ b/infrastructure/ansible/files/set_permissions.py
@@ -1,2 +1,0 @@
-import os
-os.chmod(os_path,0o660)

--- a/infrastructure/ansible/provision_jupyter.yaml
+++ b/infrastructure/ansible/provision_jupyter.yaml
@@ -60,6 +60,13 @@
           tljh-config add-item https.letsencrypt.domains {{ letsencrypt_domain }}
           tljh-config reload proxy
 
+    - name: Install the file permission setter
+      become: yes
+      ansible.builtin.copy:
+        src: files/set_permissions.py
+        dest: /opt/tljh/user/etc/jupyter/set_permissions.py
+        mode: "755"
+
     - name: Reload the tljh configuration
       become: yes
       ansible.builtin.command: tljh-config reload

--- a/infrastructure/ansible/provision_jupyter.yaml
+++ b/infrastructure/ansible/provision_jupyter.yaml
@@ -60,11 +60,11 @@
           tljh-config add-item https.letsencrypt.domains {{ letsencrypt_domain }}
           tljh-config reload proxy
 
-    - name: Install the file permission setter
+    - name: Install custom notebook configuration
       become: yes
       ansible.builtin.copy:
-        src: files/set_permissions.py
-        dest: /opt/tljh/user/etc/jupyter/set_permissions.py
+        src: files/jupyter_notebook_config.py
+        dest: /opt/tljh/user/etc/jupyter/jupyter_notebook_config.py
         mode: "755"
 
     - name: Reload the tljh configuration


### PR DESCRIPTION
Sets the file permission umask on the notebook processes so users can share notebooks with their group.