### PR TITLE
Move canary to compute box

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -45,3 +45,9 @@ jobs:
           fi
         env:
           PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
+
+      - name: Check in with Heii On-Call
+        run: |
+          curl -X POST -H 'Authorization: Bearer ${{ secrets.HEII_ON_CALL_API_KEY }}' https://api.heiioncall.com./triggers/${HEII_ON_CALL_INBOUND_TRIGGER_ID}/checkin
+        env:
+          HEII_ON_CALL_INBOUND_TRIGGER_ID: df86b926-d9c1-4584-8c91-28ffde7af8c2

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -3,7 +3,7 @@ name: Canary Run Equibind Tool
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '23 * * * *'
 
 jobs:
   canary:
@@ -45,9 +45,3 @@ jobs:
           fi
         env:
           PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
-
-      - name: Check in with Heii On-Call
-        run: |
-          curl -X POST -H 'Authorization: Bearer ${{ secrets.HEII_ON_CALL_API_KEY }}' https://api.heiioncall.com./triggers/${HEII_ON_CALL_INBOUND_TRIGGER_ID}/checkin
-        env:
-          HEII_ON_CALL_INBOUND_TRIGGER_ID: e720588c-35cd-4392-9d02-bec350aa34e9

--- a/infrastructure/ansible/files/equibind_canary.sh
+++ b/infrastructure/ansible/files/equibind_canary.sh
@@ -28,5 +28,6 @@ fi
 
 rm -rf $result_dir
 
-curl -X POST -H 'Authorization: Bearer ${HEII_ON_CALL_API_KEY}' https://api.heiioncall.com./triggers/a7660c2f-5262-4392-918b-d98aee244890/alert
+curl -X POST -H "Authorization: Bearer ${HEII_ON_CALL_API_KEY}" https://api.heiioncall.com./triggers/a7660c2f-5262-4392-918b-d98aee244890/checkin
 
+echo "Canary success"

--- a/infrastructure/ansible/files/equibind_canary.template
+++ b/infrastructure/ansible/files/equibind_canary.template
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# exit the whole script if any command returns a non-zero exit code
+set -e
+
+# plex must run from the same place as tools directory
+cd {{ repo_dir }}
+
+plex -tool equibind -input-dir {{ repo_dir }}/testdata/binding/abl 2>&1 | tee plex_out.log
+# capture the exit status of the plex call
+plex_result_code=${PIPESTATUS[0]}
+# exit immediately if plex exited with an error
+if [ $plex_result_code -gt 0 ]; then
+  exit $plex_result_code
+fi
+
+# parse the output directory from the plex stdout
+result_dir=$(cat plex_out.log | grep 'Finished processing, results written to' | sed -n 's/^.*Finished processing, results written to //p' | sed 's/\/io.json//')
+
+# exit if no docked files are found
+cd "$result_dir/entry-0/outputs"
+if [ "$(find . -name '*docked.sdf' | grep 'docked.sdf')" == "" ]; then
+  echo "No docked files found"
+  exit 1
+else
+  echo "Docked files found"
+fi
+
+rm -rf $result_dir
+
+curl -X POST -H 'Authorization: Bearer ${HEII_ON_CALL_API_KEY}' https://api.heiioncall.com./triggers/a7660c2f-5262-4392-918b-d98aee244890/alert
+

--- a/infrastructure/ansible/install_plex_tasks.yaml
+++ b/infrastructure/ansible/install_plex_tasks.yaml
@@ -1,0 +1,36 @@
+# {{ plex_dir }} must be writable by the user
+- name: Install required pip packages
+  become: yes
+  ansible.builtin.pip:
+    name:
+      - pip
+      - pyopenssl
+      - github3.py
+    state: latest
+
+- name: Get the latest plex release
+  community.general.github_release:
+    repo: plex
+    user: labdao
+    action: latest_release
+  register: latest_release
+
+- name: Download the latest plex binary
+  ansible.builtin.get_url:
+    #https://github.com/labdao/plex/releases/download/v0.7.0/plex_0.7.0_linux_amd64.tar.gz
+    url: https://github.com/labdao/plex/releases/download/{{ latest_release.tag }}/plex_{{ latest_release.tag | regex_replace('^v([0-9]\.[0-9]\.[0-9])$', '\1') }}_linux_amd64.tar.gz
+    dest: /tmp/plex_release.tar.gz
+
+- name: Unzip the plex release
+  ansible.builtin.unarchive:
+    src: /tmp/plex_release.tar.gz
+    remote_src: true
+    include: plex
+    dest: "{{ plex_dir }}"
+
+- name: Link the plex binary to the system path
+  become: yes
+  ansible.builtin.file:
+    src: "{{ plex_dir }}/plex"
+    dest: /usr/local/bin/plex
+    state: link

--- a/infrastructure/ansible/jupyter_deploy_plex.yaml
+++ b/infrastructure/ansible/jupyter_deploy_plex.yaml
@@ -4,40 +4,22 @@
   vars:
     plex_dir: /opt/local/plex
   tasks:
-    - name: Pull the plex repository
+    - name: Create plex dir, writable by user
       become: yes
+      ansible.builtin.file:
+        path: "{{ plex_dir }}"
+        owner: ubuntu
+        group: ubuntu 
+        state: directory
+
+    - name: Pull the plex repository
       ansible.builtin.git:
         repo: https://github.com/labdao/plex.git
         dest: "{{ plex_dir }}/"
 
-    - name: Get the latest plex release
-      community.general.github_release:
-        repo: plex
-        user: labdao
-        action: latest_release
-      register: latest_release
-
-    - name: Download the latest plex binary
-      become: yes
-      ansible.builtin.get_url:
-        #https://github.com/labdao/plex/releases/download/v0.7.0/plex_0.7.0_linux_amd64.tar.gz
-        url: https://github.com/labdao/plex/releases/download/{{ latest_release.tag }}/plex_{{ latest_release.tag | regex_replace('^v([0-9]\.[0-9]\.[0-9])$', '\1') }}_linux_amd64.tar.gz
-        dest: /tmp/plex_release.tar.gz
-
-    - name: Unzip the plex release
-      become: yes
-      ansible.builtin.unarchive:
-        src: /tmp/plex_release.tar.gz
-        remote_src: true
-        include: plex
-        dest: "{{ plex_dir }}"
-
-    - name: Link the plex binary to the system path
-      become: yes
-      ansible.builtin.file:
-        src: "{{ plex_dir }}/plex"
-        dest: /usr/local/bin/plex
-        state: link
+    - name: Install Plex
+      ansible.builtin.include_tasks:
+        file: install_plex_tasks.yaml
 
     - name: Add plex python wrapper to the conda path
       become: yes

--- a/infrastructure/ansible/provision_canary.yaml
+++ b/infrastructure/ansible/provision_canary.yaml
@@ -1,0 +1,54 @@
+- name: Provision Canary
+  remote_user: ubuntu
+  hosts: tag_Type_compute
+  vars:
+    canary_dir: /opt/local/canary
+    repo_dir: "{{ canary_dir }}/repo"
+    binary_dir: "{{ canary_dir }}/binary"
+  tasks:
+    - name: Install aptitude
+      become: yes
+      ansible.builtin.apt:
+        name: aptitude
+        state: latest
+        update_cache: true
+
+    - name: Install required system packages
+      become: yes
+      ansible.builtin.apt:
+        pkg:
+          - pip
+
+    - name: Ensure directories exist, writable by user
+      become: yes
+      ansible.builtin.file:
+        path: "{{ item }}"
+        owner: ubuntu
+        group: ubuntu 
+        state: directory
+      loop:
+        - "{{ repo_dir }}"
+        - "{{ binary_dir }}"
+
+    - name: Pull the plex repository
+      ansible.builtin.git:
+        repo: https://github.com/labdao/plex.git
+        dest: "{{ repo_dir }}/"
+
+    - name: Install Plex
+      ansible.builtin.include_tasks:
+        file: install_plex_tasks.yaml
+      vars:
+        plex_dir: "{{ binary_dir }}"
+
+    - name: Place canary srcript
+      ansible.builtin.template:
+        src: files/equibind_canary.template
+        dest: "{{ canary_dir }}/equibind_canary.sh"
+        mode: 'u+x'
+
+    - name: Set a cron job to run canary
+      ansible.builtin.cron:
+        name: "Run equibind canary"
+        job: "{{ canary_dir }}/equibind_canary.sh"
+        minute: "*/5"

--- a/infrastructure/ansible/provision_canary.yaml
+++ b/infrastructure/ansible/provision_canary.yaml
@@ -43,7 +43,7 @@
 
     - name: Place canary srcript
       ansible.builtin.template:
-        src: files/equibind_canary.template
+        src: files/equibind_canary.sh
         dest: "{{ canary_dir }}/equibind_canary.sh"
         mode: 'u+x'
 


### PR DESCRIPTION
* Moves the "fast" canary from GH to the compute node via a simple cron job. Now running every 5 minutes.
* Refactors the plex install script into a separate tasks file (since it is now used by the canary and the jupyterhub)
* Dials back the GH canary to run once per hour. It's still useful as a measure of outside connectivity.

Things for the future:
* Run this on a separate box, don't love that its on the compute node.
* Secrets management. I ninja dropped PLEX_ACCESS_KEY and HEII_ON_CALL_API_KEY into the instance to make this work as is.
