### PR TITLE
-tool flag removed as requirement when passing in -web3 flag

### DIFF
--- a/cmd/plex/cli.go
+++ b/cmd/plex/cli.go
@@ -14,7 +14,7 @@ func Run(toolPath, inputDir, ioJsonPath, workDir string, verbose, retry, local, 
 	// mint an NFT if web3 flag is set
 	if web3 {
 		fmt.Println("Minting NFT...")
-		web3pkg.MintNFT(toolPath, ioJsonPath)
+		web3pkg.MintNFT(ioJsonPath)
 		return
 	}
 


### PR DESCRIPTION
## Steps to test

```
go build
./plex -tool equibind -input-dir testdata/binding/abl -concurrency=2
```

Make sure you set your env variables before calling the -web3 flag

```
export RECIPIENT_WALLET=...
export AUTOTASK_WEBHOOK=...
```

Run with -web3 flag

```
./plex -input-io <path for io.json generated from first command> -web3=true
```

Visit IPFS link to check token metadata, which should include populated tool config. Optional, check your wallet profile on http://testnets.opensea.io to see your NFT (will probably need to refresh token metadata). Ensure you are connected to Optimism Goerli.

## Example

```
 aakaash@Aakaashs-MBP  ~/Desktop/code/OPENLAB/plex   374-update-the-web3-flag-call-to-not-require-using-tool-flag  go build
 aakaash@Aakaashs-MBP  ~/Desktop/code/OPENLAB/plex   374-update-the-web3-flag-call-to-not-require-using-tool-flag  ./plex -tool equibind -input-dir testdata/binding/abl -concurrency=2
Plex version (v0.7.4) up to date.
toolPath tools/equibind.json
Running IPWL tool path
Warning: tool path support will be removed and moved to the Python SDK in the future
Created working directory:  /Users/aakaash/Desktop/code/OPENLAB/plex/c68d19b8-13eb-4832-b668-ed31c51baea9
Reading tool config:  tools/equibind.json
Creating IO Entries from input directory:  testdata/binding/abl
Initialized IO file at:  /Users/aakaash/Desktop/code/OPENLAB/plex/c68d19b8-13eb-4832-b668-ed31c51baea9/io.json
Processing IO Entries
/Users/aakaash/Desktop/code/OPENLAB/plex/c68d19b8-13eb-4832-b668-ed31c51baea9
/Users/aakaash/Desktop/code/OPENLAB/plex/c68d19b8-13eb-4832-b668-ed31c51baea9/io.json
Starting to process IO entry 1 
Starting to process IO entry 0 
Job running...
Bacalhau job id: e12159af-41b5-4c53-8817-724b9b1db29c 
Job running...
Bacalhau job id: 77f1da34-db6a-4560-936c-969025b4240c 
////__🌱__////
Computing default go-libp2p Resource Manager limits based on:
    - 'Swarm.ResourceMgr.MaxMemory': "8.6 GB"
    - 'Swarm.ResourceMgr.MaxFileDescriptors': 30720

Applying any user-supplied overrides on top.
Run 'ipfs swarm limit all' to see the resulting limits.


Computing default go-libp2p Resource Manager limits based on:
    - 'Swarm.ResourceMgr.MaxMemory': "8.6 GB"
    - 'Swarm.ResourceMgr.MaxFileDescriptors': 30720

Applying any user-supplied overrides on top.
Run 'ipfs swarm limit all' to see the resulting limits.

Success processing IO entry 0 
Success processing IO entry 1 
Finished processing, results written to /Users/aakaash/Desktop/code/OPENLAB/plex/c68d19b8-13eb-4832-b668-ed31c51baea9/io.json
 aakaash@Aakaashs-MBP  ~/Desktop/code/OPENLAB/plex   374-update-the-web3-flag-call-to-not-require-using-tool-flag  ./plex -input-io /Users/aakaash/Desktop/code/OPENLAB/plex/c68d19b8-13eb-4832-b668-ed31c51baea9/io.json -web3=true
Plex version (v0.7.4) up to date.
toolPath 
Running IPWL io path
Minting NFT...
Preparing NFT metadata...
Uploading NFT metadata to IPFS...
NFT metadata uploaded to IPFS: ipfs://QmQMRi3VrnJxA3bZVXcamouou6qFb767Lw3uHbJSUjN17S
Triggering minting process via Defender Autotask...
Response from Autotask: {"autotaskRunId":"c35af8d6-6ae7-4827-ae47-04d2b3ec049d","autotaskId":"e15b3f39-28f8-4d30-9bf3-5d569bdf2e78","trigger":"webhook","status":"success","createdAt":"2023-06-07T15:17:14.642Z","requestId":"53257532-8c62-41f8-93e8-2de0513607f0","encodedLogs":"QVVUT1RBU0sgU1RBUlQKMjAyMy0wNi0wN1QxNToxNzoyNS43MjBaCUlORk8JTWludGVkIHRva2VuIHdpdGggQ0lEOiBRbVFNUmkzVnJuSnhBM2JaVlhjYW1vdW91NnFGYjc2N0x3M3VIYkpTVWpOMTdTIHRvIHJlY2lwaWVudDogMHgxZGYxM0E2NDM1NUJFMTcxMThhMDVDMDBkQTk4MTVEQWE0YWIxZWEwLiBUcmFuc2FjdGlvbiBoYXNoOiAweDE1ZTRmMGFkMjlkMWQ3NDZmN2IxN2I5Nzg1NjFjMWQzMTU2ZTA2ZjcxNDYwM2IwMjkwOTJkNTViMTM1YTViOTUKRU5EIFJlcXVlc3RJZDogNTMyNTc1MzItOGM2Mi00MWY4LTkzZTgtMmRlMDUxMzYwN2YwCkFVVE9UQVNLIENPTVBMRVRF","result":"null"}
```

Confirm tool config is on token metadata: ipfs://QmQMRi3VrnJxA3bZVXcamouou6qFb767Lw3uHbJSUjN17S
NFT: https://testnets.opensea.io/assets/optimism-goerli/0xda70c0709d4213ee8441e4731a5f662c0406ed7e/13