### PR TITLE
373 pass in plex output dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,7 @@ dist/
 job-*
 /*-*-*-*
 job.yaml
+job/*
 
 # Tool manifest
 .manifest.json

--- a/.gitignore
+++ b/.gitignore
@@ -212,7 +212,7 @@ dist/
 job-*
 /*-*-*-*
 job.yaml
-job/*
+jobs/*
 
 # Tool manifest
 .manifest.json

--- a/cmd/plex/cli.go
+++ b/cmd/plex/cli.go
@@ -10,7 +10,7 @@ import (
 	web3pkg "github.com/labdao/plex/internal/web3"
 )
 
-func Run(toolPath, inputDir, ioJsonPath, workDir string, verbose, retry, local, showAnimation bool, concurrency, layers int, web3 bool) {
+func Run(toolPath, inputDir, ioJsonPath, workDir, outputDir string, verbose, retry, local, showAnimation bool, concurrency, layers int, web3 bool) {
 	// mint an NFT if web3 flag is set
 	if web3 {
 		fmt.Println("Minting NFT...")
@@ -20,25 +20,35 @@ func Run(toolPath, inputDir, ioJsonPath, workDir string, verbose, retry, local, 
 
 	var workDirPath string
 	var err error
-	if workDir != "" {
+	if workDir != "" && outputDir != "" {
+		fmt.Println("Error: workDir and outputDir cannot be used at the same time")
+		os.Exit(1)
+	} else if workDir != "" {
 		workDirPath = workDir
 		fmt.Println("Resumed working directory: ", workDirPath)
 	} else {
 		// Create plex working directory
 		id := uuid.New()
-		cwd, err := os.Getwd()
-		if err != nil {
-			fmt.Println("Error:", err)
-			os.Exit(1)
+		var cwd string
+		if outputDir != "" {
+			cwd = outputDir
+		} else {
+			cwd, err = os.Getwd()
+			if err != nil {
+				fmt.Println("Error:", err)
+				os.Exit(1)
+			}
+			cwd = path.Join(cwd, "jobs")
 		}
 		workDirPath = path.Join(cwd, id.String())
-		err = os.Mkdir(workDirPath, 0755)
+		err = os.MkdirAll(workDirPath, 0755)
 		if err != nil {
 			fmt.Println("Error:", err)
 			os.Exit(1)
 		}
 		fmt.Println("Created working directory: ", workDirPath)
 	}
+
 	// first thing to generate io json and save to plex work dir
 	var ioEntries []ipwl.IO
 	if toolPath != "" {

--- a/internal/ipwl/ipwl.go
+++ b/internal/ipwl/ipwl.go
@@ -316,6 +316,12 @@ func cleanBacalhauOutputDir(outputsDirPath string, verbose bool) error {
 		}
 	}
 
+	// remove empty outputs folder now that files have been moved
+	err = os.Remove(bacalOutputsDirPath)
+	if err != nil {
+		fmt.Println(err)
+	}
+
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 	inputDir := flag.String("input-dir", "", "input directory path")
 	ioJsonPath := flag.String("input-io", "", "IO JSON path")
 	workDir := flag.String("work-dir", "", "PLEx working directory path")
+	outputDir := flag.String("output-dir", "", "direcoty to store job results")
 	verbose := flag.Bool("verbose", false, "show verbose debugging logs")
 	layers := flag.Int("layers", 2, "Number of layers to search in the directory path")
 	concurrency := flag.Int("concurrency", 1, "How many IO entries to run at once")
@@ -56,13 +57,13 @@ func main() {
 			os.Exit(1)
 		}
 		*retry = false // can only retry from an PLEx work dir not input directory input
-		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *verbose, *retry, *local, *showAnimation, *concurrency, *layers, *web3)
+		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *outputDir, *verbose, *retry, *local, *showAnimation, *concurrency, *layers, *web3)
 	} else if *ioJsonPath != "" {
 		fmt.Println("Running IPWL io path")
 		*retry = false // can only retry from an PLEx work dir not io json path input
-		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *verbose, *retry, *local, *showAnimation, *concurrency, *layers, *web3)
+		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *outputDir, *verbose, *retry, *local, *showAnimation, *concurrency, *layers, *web3)
 	} else if *workDir != "" {
-		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *verbose, *retry, *local, *showAnimation, *concurrency, *layers, *web3)
+		plex.Run(*toolPath, *inputDir, *ioJsonPath, *workDir, *outputDir, *verbose, *retry, *local, *showAnimation, *concurrency, *layers, *web3)
 	} else {
 		fmt.Println("Requirements invalid. Please run './plex -h' for help.")
 	}

--- a/python/plex/sdk.py
+++ b/python/plex/sdk.py
@@ -53,7 +53,7 @@ def generate_io_graph_from_tool(tool_filepath, scattering_method=ScatteringMetho
     
     return io_json_graph
 
-def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=False, retry=False, showAnimation=False, plex_path="./plex"):
+def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=False, retry=False, showAnimation=False, outputDir="./jobs", plex_path="./plex"):
     if not (isinstance(io, dict) or (isinstance(io, list) and all(isinstance(i, dict) for i in io))):
         raise ValueError('io must be a dict or a list of dicts')
 
@@ -70,7 +70,7 @@ def run_plex(io: Union[Dict, List[Dict]], concurrency=1, local=False, verbose=Fa
 
         cwd = os.getcwd()
         plex_work_dir = os.environ.get("PLEX_WORK_DIR",os.path.dirname(os.path.dirname(cwd)))
-        cmd = [plex_path, "-input-io", json_file_path, "-concurrency", str(concurrency)]
+        cmd = [plex_path, "-input-io", json_file_path, "-concurrency", str(concurrency), "-output-dir", {outputDir}]
 
         if local:
             cmd.append("-local=true")


### PR DESCRIPTION
This will by default create and drop plex/bacalhau outputs in a jobs folder in the same working directory as the plex bin. (no more messy job-ids obfuscating the plex dir!). It also allows the user to set the output directory using the -output-dir flag.

to test the default jobs directory 
```
./plex -tool equibind -input-dir testdata/binding/abl -concurrency=2            
```

to test a custom output directory, this will make a jobtest2 folder one level above the plex bin (absolute paths work as well).
```
./plex -tool equibind -input-dir testdata/binding/abl -concurrency=2  -output-dir ../jobstest2
```