### PR TITLE
Rescursively set the user on the plex repository

### DIFF
--- a/infrastructure/ansible/jupyter_deploy_plex.yaml
+++ b/infrastructure/ansible/jupyter_deploy_plex.yaml
@@ -12,6 +12,11 @@
         group: ubuntu 
         state: directory
 
+    - name: Ensure all files in plex dir are owned by the user
+      become: yes
+      ansible.builtin.command:
+        cmd: chown -R {{ ansible_user }}:{{ ansible_user }} {{ plex_dir }}
+
     - name: Pull the plex repository
       ansible.builtin.git:
         repo: https://github.com/labdao/plex.git


### PR DESCRIPTION
Forces all files in the plex repo to not be owned by root. Prevents deployment failure in case permissions have been messed with.