### PR TITLE
terraform disk space artifact

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Equibind
         run: |
           # use tee so we can see stdout in github, and parse it later
-          ./plex create -t tools/equibind.json -i testdata/binding/pdbbind_processed_size1 --autoRun=true 2>&1 | tee plex_out.log
+          plex create -t {{ repo_dir }}/tools/equibind.json -i {{ repo_dir }}/testdata/binding/pdbbind_processed_size1 --autoRun=true 2>&1 | tee plex_out.log
           # capture the exit status of the plex call
           plex_result_code=${PIPESTATUS[0]}
           # exit immediately if plex exited with an error

--- a/infrastructure/terraform/.terraform.lock.hcl
+++ b/infrastructure/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   constraints = "~> 3.0"
   hashes = [
     "h1:SFvdgX5bTGhOTMhywgjSOWlkET2el7STxdUSzxjz2pc=",
+    "h1:pn9uUSAuIE8XgqJuZ9fOs98bRN9qw4o0JHFgmwtbMyI=",
     "zh:13aabc00fee823422831bcc870227650cc765fc4c9622074d24d6d62a4ac0e37",
     "zh:1544405f0ea6b388dad7eb25c434427b2682417396da9186e1b33551e6b4adff",
     "zh:5d58394cb8e71bd4bf6ef0135f1ca6a4ad2cec937f3731b224125eb34ee059f7",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.66.1"
   constraints = "~> 4.16"
   hashes = [
+    "h1:7GytS2hRFKZDR1GgcS/nNQlyAjaMelF09HJ5xFFWneM=",
     "h1:D/qzK7fE3pgdg25W1u5GqI+VILy8UmhzXruz6c8rJ7g=",
     "zh:001c707174b7d6bf89a96cf806f925bb852d1a285fb80b81222cbeb4743bcb79",
     "zh:19bc6ac0a7fd1c564fd56c536f1743f71a5e7ca724e21ea51a6a79218939733d",

--- a/infrastructure/terraform/plex.tf
+++ b/infrastructure/terraform/plex.tf
@@ -28,7 +28,7 @@ resource "aws_instance" "plex_compute_prod" {
   availability_zone      = var.availability_zones[0]
 
   root_block_device {
-    volume_size = 1000
+    volume_size = 2000
     tags = {
       Name = "plex-prod-${each.key}"
     }


### PR DESCRIPTION
This is an accidental artifact from me thinking the below error meant our prod-compute node was out of disk space, now I realize this was the dev-node for the judge testing. I think merging is the best way to resolve, because I don't think you can shrink disk space and keep current state.

<img width="1061" alt="Screenshot 2023-06-17 at 10 37 04 AM" src="https://github.com/labdao/plex/assets/9427089/6b821a6d-5daa-4fef-904a-bb8c7b7ba83f">

I already ran 
```
terraform plan -target=aws_instance.plex_compute_prod 
terraform apply -target=aws_instance.plex_compute_prod
```

