### PR TITLE
shortcircuit github failure

### DIFF
--- a/upgrade.go
+++ b/upgrade.go
@@ -257,7 +257,8 @@ func upgradePlexVersion() error {
 	latestReleaseVersionStr, err := getLatestReleaseVersionStr()
 	if err != nil {
 		fmt.Println("Error getting latest release version:", err)
-		os.Exit(1)
+		fmt.Println("Assuming this is the latest release")
+		return nil
 	}
 
 	latestReleaseVersion, err := semver.NewVersion(latestReleaseVersionStr)


### PR DESCRIPTION
Plex will now just log there was an error if Github is down and assume it is on the latest version.

<img width="1347" alt="Screenshot 2023-06-29 at 2 57 47 PM" src="https://github.com/labdao/plex/assets/9427089/1d3653ed-bef7-4e5d-8adb-68400c0fca22">
