### PR TITLE
488 remove reference to access token from docs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,8 +29,6 @@ jobs:
       run: go build
 
     - name: Test
-      env:
-        PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}
       run: go test ./... -v
 
     - name: Run Equibind
@@ -44,5 +42,3 @@ jobs:
           echo "Docked files found:"
           find . -name '*docked.sdf' | grep 'docked.sdf'
         fi
-      env:
-        PLEX_ACCESS_TOKEN: ${{ secrets.PLEX_ACCESS_TOKEN }}

--- a/docs/docs/getting-started/install-plex.md
+++ b/docs/docs/getting-started/install-plex.md
@@ -30,9 +30,6 @@ Let's get started!
 
 **Requirements:**
 
-- [Get an access token here](https://try.labdao.xyz) (we'll email you automatically so you can use PLEX straight away).
-- No previous technical experience - we’ll walk through each step.
-
 ---
 
 ## Install PLEX
@@ -69,19 +66,7 @@ If the installation is successful, you will see a large LabDAO logo appear on yo
     speed={1.5}
 />
 
-### 3. Add an access token
-
-PLEX will prompt you for an access token - [you can get an access token here](https://try.labdao.xyz). We'll email you one automatically, so you can run a tool straight away.
-
-Type the following command into your command line, replacing "< your token here >" with the provided access token:
-
-```
-export PLEX_ACCESS_TOKEN=<your token here>
-```
-
-It is expected that after pressing **Enter**, **there will NOT be a notification** in your terminal (i.e. *nothing will happen*).
-
-### 4. [Linux only] Allow download of large results
+### 3. [Linux only] Allow download of large results
 
 If you recieve a warning about download speeds on Linux, then you can optionally paste the following command:
 


### PR DESCRIPTION
Also removes reference of access token from `go.yml` workflow