### PR TITLE
fix annotations flag

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -33,7 +33,7 @@ var createCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		if autoRun {
-			PlexRun(cid, outputDir, verbose, showAnimation, concurrency, annotations)
+			PlexRun(cid, outputDir, verbose, showAnimation, concurrency, *annotations)
 		}
 	},
 }

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -22,7 +22,7 @@ var resumeCmd = &cobra.Command{
 		dry := true
 		upgradePlexVersion(dry)
 
-		_, err := Resume(ioJsonPath, outputDir, verbose, showAnimation, retry, concurrency, annotations)
+		_, err := Resume(ioJsonPath, outputDir, verbose, showAnimation, retry, concurrency, *annotations)
 		if err != nil {
 			fmt.Println("Error:", err)
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,7 +18,7 @@ var (
 	verbose       bool
 	showAnimation bool
 	concurrency   int
-	annotations   []string
+	annotations   *[]string
 )
 
 var runCmd = &cobra.Command{
@@ -26,10 +26,11 @@ var runCmd = &cobra.Command{
 	Short: "Processes an IO JSON",
 	Long:  `Processes an IO JSON on Bacalhau and IPFS`,
 	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(*annotations)
 		dry := true
 		upgradePlexVersion(dry)
 
-		_, _, err := PlexRun(ioJsonCid, outputDir, verbose, showAnimation, concurrency, annotations)
+		_, _, err := PlexRun(ioJsonCid, outputDir, verbose, showAnimation, concurrency, *annotations)
 		if err != nil {
 			fmt.Println("Error:", err)
 			os.Exit(1)
@@ -39,6 +40,7 @@ var runCmd = &cobra.Command{
 
 func PlexRun(ioJsonCid, outputDir string, verbose, showAnimation bool, concurrency int, annotations []string) (completedIoJsonCid, ioJsonPath string, err error) {
 	// Create plex working directory
+	fmt.Println(annotations)
 	id := uuid.New()
 	var cwd string
 	if outputDir != "" {
@@ -88,7 +90,7 @@ func init() {
 	runCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	runCmd.Flags().BoolVarP(&showAnimation, "showAnimation", "", true, "Show job processing animation")
 	runCmd.Flags().IntVarP(&concurrency, "concurrency", "c", 1, "Number of concurrent operations")
-	runCmd.Flags().StringArrayP("annotations", "a", []string{}, "Annotations to add to Bacalhau job")
+	annotations = runCmd.Flags().StringArrayP("annotations", "a", []string{}, "Annotations to add to Bacalhau job")
 
 	rootCmd.AddCommand(runCmd)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -26,7 +26,6 @@ var runCmd = &cobra.Command{
 	Short: "Processes an IO JSON",
 	Long:  `Processes an IO JSON on Bacalhau and IPFS`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(*annotations)
 		dry := true
 		upgradePlexVersion(dry)
 
@@ -40,7 +39,6 @@ var runCmd = &cobra.Command{
 
 func PlexRun(ioJsonCid, outputDir string, verbose, showAnimation bool, concurrency int, annotations []string) (completedIoJsonCid, ioJsonPath string, err error) {
 	// Create plex working directory
-	fmt.Println(annotations)
 	id := uuid.New()
 	var cwd string
 	if outputDir != "" {


### PR DESCRIPTION
Just had to fix some pointer versus value shenanigans.

Below is an example with multiple annotation flags working

```
./plex run -i QmcpvDaiGnneXvHudbdz5wkgnrMr9LvRvLsYEG28UGbBeT -a ci -a josh
bacalhau describe 0dcf5020-9273-4572-a7cd-87a8ab5950a6
```

<img width="216" alt="Screenshot 2023-07-14 at 10 31 23 AM" src="https://github.com/labdao/plex/assets/9427089/d994aed0-1519-49d2-ab1a-ef4cbf3ae24c">
