### PR TITLE
docusaurus config updated with new repo for edit this page links (#516)

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -29,13 +29,13 @@ const createConfig = async () => {
             remarkPlugins: [mdxMermaid.default],
             editUrl: ({ docPath }) => {
               const pathArr = docPath.split('/');
-              let repo = 'docs';
+              let repo = 'plex';
               let pathSliceIndex = 0;
               if (pathArr.length > 1 && pathArr[0] === '_projects') {
                 repo = pathArr[1];
                 pathSliceIndex = 3;
               }
-              return `https://github.com/labdao/${repo}/edit/main/docs/${pathArr.slice(pathSliceIndex).join('/')}`
+              return `https://github.com/labdao/${repo}/edit/main/docs/docs/${pathArr.slice(pathSliceIndex).join('/')}`
             },
             routeBasePath: '/',
             exclude: [


### PR DESCRIPTION
Edit this page points to correct repo. Already deployed live on https://docs.labdao.xyz/

![Screenshot 2023-07-18 at 9 30 52 AM](https://github.com/labdao/plex/assets/29086101/0807bc08-ee8f-4bcc-b218-3f62c1263162)
