### PR TITLE
fix cobra annotation sharing bug

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -33,7 +33,6 @@ var createCmd = &cobra.Command{
 			fmt.Println("Error:", err)
 			os.Exit(1)
 		}
-		fmt.Println(*annotationsForAutoRun)
 		if autoRun {
 			_, _, err := PlexRun(cid, outputDir, verbose, showAnimation, concurrency, *annotationsForAutoRun)
 			if err != nil {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -13,10 +13,11 @@ import (
 )
 
 var (
-	toolPath string
-	inputDir string
-	autoRun  bool
-	layers   int
+	toolPath              string
+	inputDir              string
+	autoRun               bool
+	layers                int
+	annotationsForAutoRun *[]string
 )
 
 var createCmd = &cobra.Command{
@@ -32,8 +33,13 @@ var createCmd = &cobra.Command{
 			fmt.Println("Error:", err)
 			os.Exit(1)
 		}
+		fmt.Println(*annotationsForAutoRun)
 		if autoRun {
-			PlexRun(cid, outputDir, verbose, showAnimation, concurrency, *annotations)
+			_, _, err := PlexRun(cid, outputDir, verbose, showAnimation, concurrency, *annotationsForAutoRun)
+			if err != nil {
+				fmt.Println("Error:", err)
+				os.Exit(1)
+			}
 		}
 	},
 }
@@ -87,7 +93,7 @@ func init() {
 	createCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	createCmd.Flags().BoolVarP(&showAnimation, "showAnimation", "", true, "Show job processing animation")
 	createCmd.Flags().IntVarP(&concurrency, "concurrency", "c", 1, "Number of concurrent operations")
-	createCmd.Flags().StringArrayP("annotations", "a", []string{}, "Annotations to add to Bacalhau job")
+	annotationsForAutoRun = createCmd.Flags().StringArrayP("annotations", "a", []string{}, "Annotations to add to Bacalhau job")
 
 	rootCmd.AddCommand(createCmd)
 }

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	ioJsonPath string
-	retry      bool
+	ioJsonPath           string
+	retry                bool
+	annotationsForResume *[]string
 )
 
 var resumeCmd = &cobra.Command{
@@ -22,7 +23,7 @@ var resumeCmd = &cobra.Command{
 		dry := true
 		upgradePlexVersion(dry)
 
-		_, err := Resume(ioJsonPath, outputDir, verbose, showAnimation, retry, concurrency, *annotations)
+		_, err := Resume(ioJsonPath, outputDir, verbose, showAnimation, retry, concurrency, *annotationsForResume)
 		if err != nil {
 			fmt.Println("Error:", err)
 		}
@@ -51,7 +52,7 @@ func init() {
 	resumeCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	resumeCmd.Flags().BoolVarP(&showAnimation, "showAnimation", "", true, "Show job processing animation")
 	resumeCmd.Flags().IntVarP(&concurrency, "concurrency", "c", 1, "Number of concurrent operations")
-	resumeCmd.Flags().StringArrayP("annotations", "a", []string{}, "Annotations to add to Bacalhau job")
+	annotationsForResume = resumeCmd.Flags().StringArrayP("annotations", "a", []string{}, "Annotations to add to Bacalhau job")
 	resumeCmd.Flags().BoolVarP(&retry, "retry", "", true, "Retry failed jobs")
 
 	rootCmd.AddCommand(resumeCmd)


### PR DESCRIPTION
Having the same `annotations` variable in multiple cmd `init()` functions was causing annotations to always be empty when using the `plex create` cmd. This fixes that bug, which is needed to correctly tag metrics. I didn't notice this bug in my earlier PR because I only locally tested with the `plex run` command.

Running

```
./plex create -t ./tools/equibind.json -i ./testdata/binding/pdbbind_processed_size1 -a testxy -a testyx --autoRun=true
```

Yielded the following results in PSQL queries

<img width="753" alt="Screenshot 2023-07-18 at 9 48 45 AM" src="https://github.com/labdao/plex/assets/9427089/87d33417-d356-403b-bb62-c454695c3ecd">
