### PR TITLE
fail plex jobs based on bacalhau status

### DIFF
--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -91,9 +91,9 @@ func GetBacalhauJobResults(submittedJob *model.Job, showAnimation bool) (results
 			return results, err
 		}
 		if updatedJob.State.State == model.JobStateCancelled {
-			return results, fmt.Errorf("bacalhau cancelled job")
+			return results, fmt.Errorf("bacalhau cancelled job; please run `bacalhau describe %s` for more details", submittedJob.Metadata.ID)
 		} else if updatedJob.State.State == model.JobStateError {
-			return results, fmt.Errorf("bacalhau errored job")
+			return results, fmt.Errorf("bacalhau errored job; please run `bacalhau describe %s` for more details", submittedJob.Metadata.ID)
 		} else if updatedJob.State.State == model.JobStateCompleted {
 			results, err = client.GetResults(context.Background(), submittedJob.Metadata.ID)
 			if err != nil {

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -86,7 +86,6 @@ func GetBacalhauJobResults(submittedJob *model.Job, showAnimation bool) (results
 	fmt.Printf("Bacalhau job id: %s \n", submittedJob.Metadata.ID)
 
 	for i := 0; i < maxTrys; i++ {
-		// mcmenemy check for status first
 		updatedJob, _, err := client.Get(context.Background(), submittedJob.Metadata.ID)
 		if err != nil {
 			return results, err

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -86,12 +86,25 @@ func GetBacalhauJobResults(submittedJob *model.Job, showAnimation bool) (results
 	fmt.Printf("Bacalhau job id: %s \n", submittedJob.Metadata.ID)
 
 	for i := 0; i < maxTrys; i++ {
-		results, err = client.GetResults(context.Background(), submittedJob.Metadata.ID)
+		// mcmenemy check for status first
+		updatedJob, _, err := client.Get(context.Background(), submittedJob.Metadata.ID)
 		if err != nil {
 			return results, err
 		}
-		if len(results) > 0 {
-			return results, err
+		if updatedJob.State.State == model.JobStateCancelled {
+			return results, fmt.Errorf("bacalhau cancelled job")
+		} else if updatedJob.State.State == model.JobStateError {
+			return results, fmt.Errorf("bacalhau errored job")
+		} else if updatedJob.State.State == model.JobStateCompleted {
+			results, err = client.GetResults(context.Background(), submittedJob.Metadata.ID)
+			if err != nil {
+				return results, err
+			}
+			if len(results) > 0 {
+				return results, err
+			} else {
+				return results, fmt.Errorf("bacalhau job completed but no results found")
+			}
 		}
 		if showAnimation {
 			saplingIndex := i % 5


### PR DESCRIPTION
This code now Gets the Bacalhau job and checks the status before attempting to get the job results. If the Bacalhau job is in a cancelled or errored state, it will immediately return the error. Apparently, the Bacalhau GetJobResults was not raising an error in these cases.

Below is where I started a job and then used `bacalhau cancel <job_id>` to test
```
Starting to process IO entry 0 
Job running...
Bacalhau job id: 143dabba-fc73-4f15-b63e-68c98f76138a 
Error processing IO entry 0 
error getting Bacalhau job results: bacalhau cancelled job
Finished processing, results written to /Users/mcmenemy/code/plex/jobs/b855aee6-4b28-4f07-8e9b-40b7d7cb9cd3/io.json
Completed IO JSON CID: QmSPf6aGZFVNtFaxSH66UKXGGmCY5LZybWx8y2UkjJ2yL7
```