### PR TITLE
Ability for nodes to be able to self bootstrap

### DIFF
--- a/infrastructure/ansible/install_requirements.yaml
+++ b/infrastructure/ansible/install_requirements.yaml
@@ -1,0 +1,9 @@
+- name: Install requirements on the host
+  remote_user: ubuntu
+  # Ability to override host, useful to running playbook in local mode
+  hosts: "{{ target_hosts | default('all') }}"
+  tasks:
+    - name: Install collections and roles together
+      community.general.ansible_galaxy_install:
+        type: both
+        requirements_file: "{{ playbook_dir }}/requirements.yaml"

--- a/infrastructure/ansible/provision_canary.yaml
+++ b/infrastructure/ansible/provision_canary.yaml
@@ -1,6 +1,6 @@
 - name: Provision Canary
   remote_user: ubuntu
-  hosts: tag_Type_compute
+  hosts: "{{ target_hosts | default('tag_Type_compute') }}"
   vars:
     canary_dir: /opt/local/canary
     repo_dir: "{{ canary_dir }}/repo"

--- a/infrastructure/ansible/provision_compute_instance.yaml
+++ b/infrastructure/ansible/provision_compute_instance.yaml
@@ -1,6 +1,6 @@
 - name: Provision Bacalhau
   remote_user: ubuntu
-  hosts: tag_Type_compute:&tag_Env_prod
+  hosts: "{{ target_hosts | default('tag_Type_compute') }}"
   vars:
     nvidia_distribution: ubuntu2004
     nvidia_container_toolkit_key_path: /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg

--- a/infrastructure/ansible/provision_compute_only.yaml
+++ b/infrastructure/ansible/provision_compute_only.yaml
@@ -1,6 +1,7 @@
 - name: Provision Bacalhau Compute Instance
   remote_user: ubuntu
-  hosts: tag_Type_compute_only
+  # Ability to override host, useful to running playbook in local mode
+  hosts: "{{ target_hosts | default('tag_Type_compute_only') }}"
   vars:
     nvidia_distribution: ubuntu2004
     ipfs_version: "0.18.0"
@@ -47,13 +48,13 @@
     - name: flush handlers
       ansible.builtin.meta: flush_handlers
 
-    # Required docker since IPFS runs in container
+    # Install IPFS
     - name: Install IPFS
       ansible.builtin.include_tasks: tasks/install_ipfs_tasks.yaml
       tags: ipfs_install
 
     # Run Bacalhau agent
-    - name: Run Baclahau container
+    - name: Run Baclahau agent
       ansible.builtin.include_tasks: tasks/install_bacalhau_tasks.yaml
       tags: bacalhau
 

--- a/infrastructure/ansible/provision_jupyter.yaml
+++ b/infrastructure/ansible/provision_jupyter.yaml
@@ -1,6 +1,6 @@
 - name: Provision Jupyter Notebook Instances
   remote_user: ubuntu
-  hosts: tag_Type_jupyter_notebook
+  hosts: "{{ target_hosts | default('tag_Type_jupyter_notebook') }}"
   vars:
     letsencrypt_email: "josh@labdao.xyz"
     letsencrypt_domain: "jupyter.labdao.xyz"

--- a/infrastructure/ansible/provision_receptor.yaml
+++ b/infrastructure/ansible/provision_receptor.yaml
@@ -1,6 +1,6 @@
 - name: Provision Receptor
   remote_user: ubuntu
-  hosts: tag_Type_receptor
+  hosts: "{{ target_hosts | default('tag_Type_receptor') }}"
   vars:
     plex_dir: /opt/local/plex
     receptor_dir: /opt/local/receptor

--- a/infrastructure/ansible/provision_requester.yaml
+++ b/infrastructure/ansible/provision_requester.yaml
@@ -1,6 +1,6 @@
 - name: Provision Bacalhau Requester
   remote_user: ubuntu
-  hosts: tag_Type_requester
+  hosts: "{{ target_hosts | default('tag_Type_requester') }}"
   vars:
     ipfs_version: "0.18.0"
     ipfs_path: "/opt/ipfs"

--- a/infrastructure/ansible/tasks/install_bacalhau_tasks.yaml
+++ b/infrastructure/ansible/tasks/install_bacalhau_tasks.yaml
@@ -7,16 +7,53 @@
   no_log: true
   check_mode: false
 
+- name: Set fact for currently installed version
+  ansible.builtin.set_fact:
+    bacalhau_installed_version: "{{ existing_bacalhau_version.stdout.split('Server Version: ')[1] }}"
+  when: existing_bacalhau_version.stdout != ''
+
 - name: Print installed kubo version
   ansible.builtin.debug:
-    msg: "Installed bacalhau version: {{ existing_bacalhau_version.stdout.split('Server Version: ')[1] }} vs {{ bacalhau_version }}"
-  when: existing_kubo_version.stdout != ''
+    msg: "Installed bacalhau version: {{ bacalhau_installed_version }} vs {{ bacalhau_version }}"
+  when: bacalhau_installed_version is defined
 
-# Compare the latest version of bacalhau with the version that is already installed, if any.
-- name: Install or update bacalhau
-  when:
-    "(existing_bacalhau_version.stdout == '') or (existing_bacalhau_version.stdout.split('Server Version: ')[1] != bacalhau_version)"
+- name: Only do this if bacalhau isnt installed or upgrade is needed
+  when: bacalhau_installed_version is undefined or bacalhau_installed_version != bacalhau_version
   block:
+    - name: Fetch AWS EC2 Metadata facts
+      amazon.aws.ec2_metadata_facts:
+
+    - name: Print environment info
+      ansible.builtin.debug:
+        msg: "Running on environment: {{ ansible_ec2_tags_instance_Env }}"
+      when: ansible_ec2_tags_instance_Env is defined
+
+    - name: Set fact when its prod node
+      ansible.builtin.set_fact:
+        bacalhau_hostname: "bacalhau.labdao.xyz"
+        requester_hostname: "requester.labdao.xyz"
+      when: ansible_ec2_tags_instance_Env is defined and ansible_ec2_tags_instance_Env | lower == "prod"
+
+    - name: Set fact when its non-prod node
+      ansible.builtin.set_fact:
+        bacalhau_hostname: "bacalhau.{{ ansible_ec2_tags_instance_Env | lower }}.labdao.xyz"
+        requester_hostname: "requester.{{ ansible_ec2_tags_instance_Env | lower }}.labdao.xyz"
+      when: ansible_ec2_tags_instance_Env is defined and ansible_ec2_tags_instance_Env | lower != "prod"
+
+    # Bacalhau PeerID, example `curl -s bacalhau.staging.labdao.xyz:1234/node_info | jq -r '.PeerInfo.ID'`
+    - name: Determine requester bacalhau peer id
+      ansible.builtin.uri:
+        url: "http://{{ bacalhau_hostname }}:1234/node_info"
+        return_content: true
+      register: bacalhau_output
+      when: bacalhau_hostname is defined
+
+    - name: Set requester_peer url
+      ansible.builtin.set_fact:
+        # requester_peer: /dns4/requester.staging.labdao.xyz/tcp/1235/p2p/QmeLa2fx2FMNDWbeY3UqjELc1MbKwNxggcmdBmLZepY6VK
+        requester_peer: "/dns4/{{ requester_hostname }}/tcp/1235/p2p/{{ bacalhau_output.content | from_json | community.general.json_query('PeerInfo.ID') }}"
+      when: requester_hostname is defined
+
     - name: Download Bacalhau binary
       become: true
       ansible.builtin.unarchive:

--- a/infrastructure/ansible/tasks/install_ipfs_tasks.yaml
+++ b/infrastructure/ansible/tasks/install_ipfs_tasks.yaml
@@ -56,6 +56,8 @@
         line: IPFS_PATH={{ ipfs_path }}
 
     - name: Initiazlie IPFS
+      become: true
+      become_user: ubuntu
       ansible.builtin.command:
         cmd: ipfs init
         creates: "{{ ipfs_path }}/config"
@@ -63,6 +65,8 @@
         IPFS_PATH: "{{ ipfs_path }}"
 
     - name: Configure IPFS
+      become: true
+      become_user: ubuntu
       ansible.builtin.shell: |
         ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
         ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
@@ -85,7 +89,6 @@
         enabled: true
 
     - name: Wait for IPFS to be healthy
-      become: true
       command:
         cmd: ipfs --api=/ip4/127.0.0.1/tcp/5001 dag stat /ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn
       register: ipfs_healthcheck
@@ -97,7 +100,44 @@
   when: bacalhau_node_type == "compute"
   tags: ipfs_swarm
   block:
-    - name: Run ipfs swarm inside container
+    - name: Fetch AWS EC2 Metadata facts
+      amazon.aws.ec2_metadata_facts:
+
+    - name: Print environment info
+      ansible.builtin.debug:
+        msg: "Running on environment: {{ ansible_ec2_tags_instance_Env }}"
+      when: ansible_ec2_tags_instance_Env is defined
+
+    - name: Set fact when its prod node
+      ansible.builtin.set_fact:
+        bacalhau_hostname: "bacalhau.labdao.xyz"
+        requester_hostname: "requester.labdao.xyz"
+      when: ansible_ec2_tags_instance_Env is defined and ansible_ec2_tags_instance_Env | lower == "prod"
+
+    - name: Set fact when its non-prod node
+      ansible.builtin.set_fact:
+        bacalhau_hostname: "bacalhau.{{ ansible_ec2_tags_instance_Env | lower }}.labdao.xyz"
+        requester_hostname: "requester.{{ ansible_ec2_tags_instance_Env | lower }}.labdao.xyz"
+      when: ansible_ec2_tags_instance_Env is defined and ansible_ec2_tags_instance_Env | lower != "prod"
+
+    # curl -s -X POST http://bacalhau.staging.labdao.xyz:5001/api/v0/config/show | jq -r '.Identity.PeerID'
+    - name: Determine ipfs peer id
+      ansible.builtin.uri:
+        url: "http://{{ bacalhau_hostname }}:5001/api/v0/config/show"
+        method: POST
+        return_content: true
+      register: ipfs_output
+      when: bacalhau_hostname is defined
+
+    - name: Set requester_peer url
+      ansible.builtin.set_fact:
+        # IPFS PeerID, `curl -s -X POST http://bacalhau.staging.labdao.xyz:5001/api/v0/config/show | jq -r '.Identity.PeerID'`
+        requester_ipfs_peer: "/dns4/{{ requester_hostname }}/tcp/4001/p2p/{{ ipfs_output.content | from_json | community.general.json_query('Identity.PeerID') }}"
+      when: requester_hostname is defined
+
+    - name: Run ipfs swarm
+      become: true
+      become_user: ubuntu
       command:
         cmd: ipfs swarm connect {{ requester_ipfs_peer }}
       environment:

--- a/infrastructure/ansible/vars/prod.yaml
+++ b/infrastructure/ansible/vars/prod.yaml
@@ -1,4 +1,5 @@
 ---
+
 receptor_url: http://ip-172-31-82-127.ec2.internal:8080/judge
 requester_peer: /ip4/172.31.90.74/tcp/1235/p2p/QmbETsVtL1sQ97KKV1jPQA5ng8RSyzPWUiDgRBQp7AcjRt
 requester_ipfs_peer: /ip4/172.31.90.74/tcp/4001/p2p/12D3KooWAjYbsjXAQWqPRCPTTaMkDkUjhschznkLrDoKUyfQvHAP

--- a/infrastructure/ansible/vars/staging.yaml
+++ b/infrastructure/ansible/vars/staging.yaml
@@ -1,9 +1,3 @@
 ---
 
-# Bacalhau PeerID, example `curl -s bacalhau.staging.labdao.xyz:1234/node_info | jq -r '.PeerInfo.ID'`
-requester_peer: /dns4/requester.staging.labdao.xyz/tcp/1235/p2p/QmeLa2fx2FMNDWbeY3UqjELc1MbKwNxggcmdBmLZepY6VK
-
-# IPFS PeerID, `curl -s -X POST http://bacalhau.staging.labdao.xyz:5001/api/v0/config/show | jq -r '.Identity.PeerID'`
-requester_ipfs_peer: /dns4/requester.staging.labdao.xyz/tcp/4001/p2p/12D3KooWKmRk1TpoiHyXxEjsyjLqhWckkxdy5ybdSL6DGKAs1Ag2
-
 nvidia_distribution: ubuntu2204

--- a/infrastructure/terraform/jupyter.tf
+++ b/infrastructure/terraform/jupyter.tf
@@ -7,6 +7,13 @@ resource "aws_instance" "plex_jupyter" {
   key_name               = var.key_main
   availability_zone      = var.availability_zones[0]
 
+  # Enabling metadata option with instance metadata tags - required for self bootstrapping
+  metadata_options {
+    http_endpoint          = "enabled"
+    http_tokens            = "optional"
+    instance_metadata_tags = "enabled"
+  }
+
   root_block_device {
     volume_size = 1000
   }

--- a/infrastructure/terraform/plex.tf
+++ b/infrastructure/terraform/plex.tf
@@ -6,6 +6,13 @@ resource "aws_instance" "plex_prod" {
   key_name               = var.key_main
   availability_zone      = var.availability_zones[0]
 
+  # Enabling metadata option with instance metadata tags - required for self bootstrapping
+  metadata_options {
+    http_endpoint          = "enabled"
+    http_tokens            = "optional"
+    instance_metadata_tags = "enabled"
+  }
+
   root_block_device {
     volume_size = 1000
     tags = {
@@ -26,6 +33,13 @@ resource "aws_instance" "plex_compute_prod" {
   vpc_security_group_ids = [aws_security_group.plex.id, aws_security_group.internal.id]
   key_name               = var.key_main
   availability_zone      = var.availability_zones[0]
+
+  # Enabling metadata option with instance metadata tags - required for self bootstrapping
+  metadata_options {
+    http_endpoint          = "enabled"
+    http_tokens            = "optional"
+    instance_metadata_tags = "enabled"
+  }
 
   root_block_device {
     volume_size = 2000
@@ -53,6 +67,13 @@ resource "aws_instance" "plex_compute_only" {
   key_name               = var.key_main
   availability_zone      = var.availability_zones[0]
 
+  # Enabling metadata option with instance metadata tags - required for self bootstrapping
+  metadata_options {
+    http_endpoint          = "enabled"
+    http_tokens            = "optional"
+    instance_metadata_tags = "enabled"
+  }
+
   root_block_device {
     volume_size = 1000
     tags = {
@@ -75,6 +96,13 @@ resource "aws_instance" "plex_requester" {
   vpc_security_group_ids = [aws_security_group.plex.id, aws_security_group.internal.id]
   key_name               = var.key_main
   availability_zone      = var.availability_zones[0]
+
+  # Enabling metadata option with instance metadata tags - required for self bootstrapping
+  metadata_options {
+    http_endpoint          = "enabled"
+    http_tokens            = "optional"
+    instance_metadata_tags = "enabled"
+  }
 
   root_block_device {
     volume_size = 10
@@ -104,6 +132,15 @@ resource "cloudflare_record" "plex_compute_prod" {
   ttl     = 3600
 }
 
+# Private DNS record for requester 
+resource "cloudflare_record" "plex_compute_prod_private" {
+  zone_id = var.cloudflare_zone_id
+  name    = "requester"
+  value   = aws_eip.plex_prod.private_dns
+  type    = "CNAME"
+  ttl     = 3600
+}
+
 resource "aws_instance" "receptor" {
   for_each      = toset(["judgy"])
   ami           = "ami-053b0d53c279acc90"
@@ -112,6 +149,13 @@ resource "aws_instance" "receptor" {
   vpc_security_group_ids = [aws_security_group.external_ssh.id, aws_security_group.internal.id]
   key_name               = var.key_main
   availability_zone      = var.availability_zones[0]
+
+  # Enabling metadata option with instance metadata tags - required for self bootstrapping
+  metadata_options {
+    http_endpoint          = "enabled"
+    http_tokens            = "optional"
+    instance_metadata_tags = "enabled"
+  }
 
   root_block_device {
     volume_size = 10

--- a/infrastructure/terraform/staging/asg.tf
+++ b/infrastructure/terraform/staging/asg.tf
@@ -50,6 +50,7 @@ resource "aws_autoscaling_group" "labdao_compute_asg" {
       }
     }
   }
+
 }
 
 # NOTE: autoscaling to stop instances at Friday 8pm EST
@@ -58,6 +59,40 @@ resource "aws_autoscaling_schedule" "labdao_compute_asg_schedule_0" {
   autoscaling_group_name = aws_autoscaling_group.labdao_compute_asg.name
   recurrence             = "00 20 * * FRI"
   time_zone              = "America/Toronto"
+
+  # NOT Adjusting
+  min_size = -1
+
+  # NOT Adjusting
+  max_size = -1
+
+  # NOTE: Dropping to 0
+  desired_capacity = 0
+}
+
+# NOTE: autoscaling to start single instance on Monday 8am CEST
+resource "aws_autoscaling_schedule" "labdao_compute_asg_schedule_1" {
+  scheduled_action_name  = "labdao-${var.environment}-compute-asg-count-1"
+  autoscaling_group_name = aws_autoscaling_group.labdao_compute_asg.name
+  recurrence             = "00 8 * * MON"
+  time_zone              = "Europe/Berlin"
+
+  # NOT Adjusting
+  min_size = -1
+
+  # NOT Adjusting
+  max_size = -1
+
+  # NOTE: Upping to 1
+  desired_capacity = 1
+}
+
+# NOTE: autoscaling to stop instances at Friday 8pm EST
+resource "aws_autoscaling_schedule" "labdao_compute_asg_schedule_0" {
+  scheduled_action_name  = "labdao-${var.environment}-compute-asg-count-0"
+  autoscaling_group_name = aws_autoscaling_group.labdao_compute_asg.name
+  recurrence             = "00 20 * * FRI"
+  time_zone              = "America/New_York"
 
   # NOT Adjusting
   min_size = -1

--- a/infrastructure/terraform/staging/files/userdata.sh
+++ b/infrastructure/terraform/staging/files/userdata.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+set -e
+
+export ANSIBLE_VERSION="8.2.0"
+export ANSIBLE_CHECKOUT="main"
+
 echo "Installing awscli"
 apt-get update
 apt-get -y --no-install-recommends install awscli git python3-pip
@@ -9,5 +14,62 @@ snap install amazon-ssm-agent --classic
 systemctl enable snap.amazon-ssm-agent.amazon-ssm-agent.service
 systemctl start snap.amazon-ssm-agent.amazon-ssm-agent.service
 
-echo "Install Ansible"
-pip3 install ansible
+echo "Determine instance type info from tag"
+INSTANCE_TYPE_TAG=$(curl -s http://instance-data/latest/meta-data/tags/instance/Type)
+
+# Check if vars file needs loading - by checking if file with environment name exists
+LOAD_EXTRA_VARS_FILE="false"
+# If environment tag is not empty
+if [[ "x${environment}" != "x" ]] ;then
+  VARS_FILE="infrastructure/ansible/vars/${environment}.yaml"
+  VARS_FILE_URL="https://raw.githubusercontent.com/labdao/plex/$${ANSIBLE_CHECKOUT}/$${VARS_FILE}"
+  # Check if extra-vars file exists
+  if [ $(curl -LI "$${VARS_FILE_URL}" -o /dev/null -w '%%{http_code}\n' -s) == "200" ]; then
+    LOAD_EXTRA_VARS_FILE="true"
+    wget "$${VARS_FILE_URL}"
+  fi
+fi
+
+echo "Install Ansible $${ANSIBLE_VERSION}"
+pip3 install ansible==$${ANSIBLE_VERSION}
+
+echo "Run provided playbooks"
+
+for playbook in infrastructure/ansible/install_requirements.yaml infrastructure/ansible/provision_$${INSTANCE_TYPE_TAG}.yaml; do
+  ANSIBLE_TMP_DIR="$(mktemp -d)"
+
+  # Check if vars file needs loading
+  if [[ "$${LOAD_EXTRA_VARS_FILE}" == "true" ]] ;then
+
+    echo "Running \"$${playbook}\" under temp directory $${ANSIBLE_TMP_DIR} with extra-vars file \"$${VARS_FILE}\""
+    /usr/local/bin/ansible-pull \
+     --accept-host-key \
+     --verbose \
+     --extra-vars 'target_hosts=localhost' \
+     --extra-vars "@${environment}.yaml" \
+     --connection 'local' \
+     --url https://github.com/labdao/plex.git \
+     --checkout "$${ANSIBLE_CHECKOUT}" \
+     --directory "$${ANSIBLE_TMP_DIR}" \
+     --purge \
+     --limit localhost \
+     "$${playbook}"
+  else
+
+    echo "Running \"$${playbook}\" under temp directory $${ANSIBLE_TMP_DIR}"
+    /usr/local/bin/ansible-pull \
+     --accept-host-key \
+     --verbose \
+     --extra-vars 'target_hosts=localhost' \
+     --connection 'local' \
+     --url https://github.com/labdao/plex.git \
+     --checkout "$${ANSIBLE_CHECKOUT}" \
+     --directory "$${ANSIBLE_TMP_DIR}" \
+     --purge \
+     --limit localhost \
+     "$${playbook}"
+  fi
+
+  # remove ansible temp directory
+  rm -rf "$${ANSIBLE_TMP_DIR}"
+done

--- a/infrastructure/terraform/staging/launch_templates.tf
+++ b/infrastructure/terraform/staging/launch_templates.tf
@@ -46,7 +46,7 @@ resource "aws_launch_template" "labdao_requester" {
       Type = "requester"
     }
   }
-  user_data = base64encode(templatefile("${path.module}/files/userdata.sh", { name = var.environment }))
+  user_data = base64encode(templatefile("${path.module}/files/userdata.sh", { environment = var.environment }))
 }
 
 resource "aws_launch_template" "labdao_compute" {
@@ -97,5 +97,5 @@ resource "aws_launch_template" "labdao_compute" {
     }
   }
 
-  user_data = base64encode(templatefile("${path.module}/files/userdata.sh", { name = var.environment }))
+  user_data = base64encode(templatefile("${path.module}/files/userdata.sh", { environment = var.environment }))
 }


### PR DESCRIPTION
- added termination policy and increased max_size for compute
- only target running hosts
- added asg schedule to bring down compute nodes over the weekend
- GH-535 added idempotency by adding version check condition
- [GH-541] Ability to run playbooks in local mode
- [GH-541] updated user-data to run ansible-pull
- wip
- fixing spell mistake
- added private dns for reaching internally
- enabling instance_metadata_tags for bootstrapping
- ability to load extra vars file if exists
- some cleanup
- fixing some stuff
- adjusting install requirements playbook
- its yaml not yml :)
- become ubuntu user
- downloading vars file since it requires it
