### PR TITLE
more direct and useful link for users to view their nfts

### DIFF
--- a/internal/web3/nft.go
+++ b/internal/web3/nft.go
@@ -178,7 +178,7 @@ func triggerMinting(recipientAddress, cid string) error {
 		fmt.Println("\U0001F331\U0001F331\U0001F331\U0001F331\U0001F331") // 5 saplings for open science
 		fmt.Println("Minting process successful.")
 		fmt.Println("Thank you for making science more reproducible, open, and collaborative!")
-		fmt.Println("You can view your ProofOfScience NFT at https://testnets.opensea.io/.")
+		fmt.Println("You can view your ProofOfScience NFT at https://testnets.opensea.io/account.")
 		fmt.Println("\U0001F331\U0001F331\U0001F331\U0001F331\U0001F331") // 5 more saplings for open science
 	} else {
 		fmt.Println("Minting process failed.")


### PR DESCRIPTION
We point users to https://testnets.opensea.io/account as a print statement in our tutorial notebooks. This link is better than what the client shows (https://testnets.opensea.io/).

This change logs the account endpoint directly in the client for better UX. We no longer need an extra print statement in the notebooks