### PR TITLE
Allow metabase IPs to Receptor RDS Instance

### DIFF
--- a/infrastructure/terraform/network.tf
+++ b/infrastructure/terraform/network.tf
@@ -36,3 +36,18 @@ resource "aws_security_group_rule" "ingress_ssh_external" {
   ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.external_ssh.id
 }
+
+resource "aws_security_group" "allow_metabase_postgres" {
+  name        = "allow-metabase"
+  description = "Allow Metabase IPs to access RDS"
+}
+
+resource "aws_security_group_rule" "ingress_allow_metabase_postgres" {
+  type              = "ingress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  # https://www.metabase.com/docs/latest/cloud/ip-addresses-to-whitelist
+  cidr_blocks       = ["18.207.81.126/32", "3.211.20.157/32", "50.17.234.169/32"]
+  security_group_id = aws_security_group.allow_metabase_postgres.id
+}

--- a/infrastructure/terraform/plex.tf
+++ b/infrastructure/terraform/plex.tf
@@ -181,5 +181,6 @@ resource "aws_db_instance" "default" {
   username                    = "receptor"
   skip_final_snapshot         = true
   manage_master_user_password = true
-  vpc_security_group_ids      = [aws_security_group.internal.id, ]
+  vpc_security_group_ids      = [aws_security_group.internal.id, aws_security_group.allow_metabase_postgres.id]
+  publicly_accessible	        = true
 }


### PR DESCRIPTION
I'm getting the receptor job data into metabase so Niklas can have real time access to usage metrics.

In the medium-term this probably means we will want to set up a read replica on receptor instance to prevent metatabase from bogging down production. For now, were adding so few rows per day, I'm not really worried.