### PR TITLE
`plex_run` adds "python" annotation by default

### DIFF
--- a/python/dev/example.py
+++ b/python/dev/example.py
@@ -19,7 +19,13 @@ initial_io_cid = plex_init(
     small_molecule=small_molecules,
     protein=proteins)
 
-completed_io_cid, io_file_path = plex_run(initial_io_cid, output_dir=jobs_dir, plex_path=plex_path)
+# Custom annotations for testing
+custom_annotations = ["custom1", "custom2"]
+
+completed_io_cid, io_file_path = plex_run(initial_io_cid, output_dir=jobs_dir, annotations=custom_annotations, plex_path=plex_path)
+
+# Print annotations to verify
+print(f"\nAnnotations used in plex_run: {custom_annotations}\n")
 
 vectors = plex_vectorize(io_file_path, CoreTools.EQUIBIND.value, plex_path=plex_path)
 

--- a/python/dev/example.py
+++ b/python/dev/example.py
@@ -20,7 +20,7 @@ initial_io_cid = plex_init(
     protein=proteins)
 
 # Custom annotations for testing
-custom_annotations = ["custom1", "custom2"]
+custom_annotations = ["python_example", "test"]
 
 completed_io_cid, io_file_path = plex_run(initial_io_cid, output_dir=jobs_dir, annotations=custom_annotations, plex_path=plex_path)
 

--- a/python/pip-description.md
+++ b/python/pip-description.md
@@ -1,14 +1,14 @@
-# PLEX
+# plex
 
 **A Python package for running scientific workflows on a decentralized infrastructure**
 
-PLEX is a Python package that allows scientists to run their workflows on a decentralized infrastructure. It is a client that can be used to run containers on a public network, and it supports distributed compute and storage. This means that scientists can use PLEX to run their workflows on any machine that is connected to the internet, and they can also use GPUs if they need them.
+Plex is a Python package that allows scientists to run their workflows on a decentralized infrastructure. It is a client that can be used to run containers on a public network, and it supports distributed compute and storage. This means that scientists can use PLEX to run their workflows on any machine that is connected to the internet, and they can also use GPUs if they need them.
 
-PLEX is strictly composable, which means that every tool in PLEX has declared inputs and outputs. This makes it easy to plug together tools by different authors, and it also makes it easier to share results with other scientists.
+Plex is strictly composable, which means that every tool in plex has declared inputs and outputs. This makes it easy to plug together tools by different authors, and it also makes it easier to share results with other scientists.
 
-In addition, every file processed by PLEX has a deterministic address based on its content. This means that you can always track your files and share the right results with other scientists.
+In addition, every file processed by plex has a deterministic address based on its content. This means that you can always track your files and share the right results with other scientists.
 
-The PLEX pip package provides a simple and easy way to install and use PLEX. It also includes documentation and examples to help you get started.
+The plex pip package provides a simple and easy way to install and use PLEX. It also includes documentation and examples to help you get started.
 
 **Features**
 - Distributed compute and storage
@@ -24,7 +24,7 @@ The PLEX pip package provides a simple and easy way to install and use PLEX. It 
 
 **Installation**
 
-To install the PLEX pip package, you can use the following command:
+To install the plex pip package, you can use the following command:
 
 ```
 pip install PlexLabExchange
@@ -32,8 +32,8 @@ pip install PlexLabExchange
 
 **Documentation**
 
-The PLEX documentation can be found at https://docs.labdao.xyz.
+The plex documentation can be found at https://docs.labdao.xyz.
 
 **Contributing**
 
-If you would like to contribute to PLEX, you can do so by submitting a pull request on the GitHub [repository](https://github.com/labdao/plex).
+If you would like to contribute to plex, you can do so by submitting a pull request on the GitHub [repository](https://github.com/labdao/plex).

--- a/python/pip-description.md
+++ b/python/pip-description.md
@@ -2,13 +2,13 @@
 
 **A Python package for running scientific workflows on a decentralized infrastructure**
 
-Plex is a Python package that allows scientists to run their workflows on a decentralized infrastructure. It is a client that can be used to run containers on a public network, and it supports distributed compute and storage. This means that scientists can use PLEX to run their workflows on any machine that is connected to the internet, and they can also use GPUs if they need them.
+Plex is a Python package that allows scientists to run their workflows on a decentralized infrastructure. It is a client that can be used to run containers on a public network, and it supports distributed compute and storage. This means that scientists can use plex to run their workflows on any machine that is connected to the internet, and they can also use GPUs if they need them.
 
 Plex is strictly composable, which means that every tool in plex has declared inputs and outputs. This makes it easy to plug together tools by different authors, and it also makes it easier to share results with other scientists.
 
 In addition, every file processed by plex has a deterministic address based on its content. This means that you can always track your files and share the right results with other scientists.
 
-The plex pip package provides a simple and easy way to install and use PLEX. It also includes documentation and examples to help you get started.
+The plex pip package provides a simple and easy way to install and use plex. It also includes documentation and examples to help you get started.
 
 **Features**
 - Distributed compute and storage

--- a/python/setup.py
+++ b/python/setup.py
@@ -56,7 +56,7 @@ with open("pip-description.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="PlexLabExchange",
-    version="0.8.21",
+    version="0.8.22",
     packages=find_packages(where='src'),  # tell setuptools to look in the 'src' directory for packages
     package_dir={'': 'src'},  # tell setuptools that the packages are under the 'src' directory
     cmdclass={

--- a/python/src/plex/__init__.py
+++ b/python/src/plex/__init__.py
@@ -178,7 +178,11 @@ def plex_run(io_json_cid: str, output_dir="", verbose=False, show_animation=Fals
     if "python" not in annotations:
         annotations.append("python")
 
-    cmd.append(f"--annotations={','.join(annotations)}")
+    # Add each annotation as a separate parameter to cmd
+    for annotation in annotations:
+        cmd.append(f"--annotations={annotation}")
+
+    print(annotations)
 
     if not show_animation:  # default is true in the CLI
         cmd.append("--showAnimation=false")

--- a/python/src/plex/__init__.py
+++ b/python/src/plex/__init__.py
@@ -157,7 +157,7 @@ def plex_create(tool_path: str, input_dir: str, layers=2, output_dir="", verbose
     return io_json_cid
 
 
-def plex_run(io_json_cid: str, output_dir="", verbose=False, show_animation=False, concurrency="1", annotations=["python"], plex_path="plex"):
+def plex_run(io_json_cid: str, output_dir="", verbose=False, show_animation=False, concurrency="1", annotations=None, plex_path="plex"):
     cwd = os.getcwd()
     plex_work_dir = os.environ.get("PLEX_WORK_DIR", os.path.dirname(cwd))
     cmd = [plex_path, "run", "-i", io_json_cid]
@@ -170,6 +170,9 @@ def plex_run(io_json_cid: str, output_dir="", verbose=False, show_animation=Fals
 
     if concurrency:
         cmd.append(f"--concurrency={concurrency}")
+
+    if annotations is None:
+        annotations = []
 
     # Ensure "python" is always in the annotations list
     if "python" not in annotations:

--- a/python/src/plex/__init__.py
+++ b/python/src/plex/__init__.py
@@ -157,9 +157,8 @@ def plex_create(tool_path: str, input_dir: str, layers=2, output_dir="", verbose
     return io_json_cid
 
 
-def plex_run(io_json_cid: str, output_dir="", verbose=False, show_animation=False, concurrency="1", annotations=[], plex_path="plex"):
+def plex_run(io_json_cid: str, output_dir="", verbose=False, show_animation=False, concurrency="1", annotations=["python"], plex_path="plex"):
     cwd = os.getcwd()
-    # plex_work_dir = os.environ.get("PLEX_WORK_DIR", os.path.dirname(os.path.dirname(cwd)))
     plex_work_dir = os.environ.get("PLEX_WORK_DIR", os.path.dirname(cwd))
     cmd = [plex_path, "run", "-i", io_json_cid]
 
@@ -172,10 +171,13 @@ def plex_run(io_json_cid: str, output_dir="", verbose=False, show_animation=Fals
     if concurrency:
         cmd.append(f"--concurrency={concurrency}")
 
-    if annotations:
-        cmd.append(f"--annotations={annotations.join(',')}")
+    # Ensure "python" is always in the annotations list
+    if "python" not in annotations:
+        annotations.append("python")
 
-    if not show_animation: # default is true in the CLI
+    cmd.append(f"--annotations={','.join(annotations)}")
+
+    if not show_animation:  # default is true in the CLI
         cmd.append("--showAnimation=false")
 
     with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1, universal_newlines=True, cwd=plex_work_dir) as p:

--- a/python/src/plex/__init__.py
+++ b/python/src/plex/__init__.py
@@ -182,8 +182,6 @@ def plex_run(io_json_cid: str, output_dir="", verbose=False, show_animation=Fals
     for annotation in annotations:
         cmd.append(f"--annotations={annotation}")
 
-    print(annotations)
-
     if not show_animation:  # default is true in the CLI
         cmd.append("--showAnimation=false")
 


### PR DESCRIPTION
The `plex_run` command now automatically includes a "python" annotation by default. This is to distinguish between using plex in Python and Go for analytics purposes.

**To Test:**
```
cd python/dev
pip install -e ../
python example.py
```

**To Do Before Merging:**
[ ] Upgrade pip pkg version number in python/setup.py
[ ] Publish new pip pkg version