### PR TITLE
`maxTime` flag propagates to Bacalhau `Job.Spec.Timeout`

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -31,7 +31,7 @@ var upgradeCmd = &cobra.Command{
 }
 
 const (
-	CurrentPlexVersion = "v0.10.2"
+	CurrentPlexVersion = "v0.10.3"
 	ReleaseURL         = "https://api.github.com/repos/labdao/plex/releases/latest"
 	ToolsURL           = "https://api.github.com/repos/labdao/plex/contents/tools?ref=main"
 )

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -27,7 +27,7 @@ func GetBacalhauApiHost() string {
 	}
 }
 
-func CreateBacalhauJob(cid, container, cmd string, memory int, gpu, network bool, annotations []string) (job *model.Job, err error) {
+func CreateBacalhauJob(cid, container, cmd string, maxTime, memory int, gpu, network bool, annotations []string) (job *model.Job, err error) {
 	job, err = model.NewJobWithSaneProductionDefaults()
 	if err != nil {
 		return nil, err
@@ -37,6 +37,7 @@ func CreateBacalhauJob(cid, container, cmd string, memory int, gpu, network bool
 	job.Spec.Publisher = model.PublisherIpfs
 	job.Spec.Docker.Entrypoint = []string{"/bin/bash", "-c", cmd}
 	job.Spec.Annotations = annotations
+	job.Spec.Timeout = float64(maxTime) * 60
 
 	// had problems getting selector to work in bacalhau v0.28
 	var selectorLabel string

--- a/internal/bacalhau/bacalhau_test.go
+++ b/internal/bacalhau/bacalhau_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestCreateBalhauJob(t *testing.T) {
+func TestCreateBacalhauJob(t *testing.T) {
 	cid := "bafybeibuivbwkakim3hkgphffaipknuhw4epjfu3bstvsuv577spjhbvju"
 	container := "ubuntu"
 	cmd := "echo DeSci"

--- a/internal/bacalhau/bacalhau_test.go
+++ b/internal/bacalhau/bacalhau_test.go
@@ -9,12 +9,17 @@ func TestCreateBalhauJob(t *testing.T) {
 	cid := "bafybeibuivbwkakim3hkgphffaipknuhw4epjfu3bstvsuv577spjhbvju"
 	container := "ubuntu"
 	cmd := "echo DeSci"
+	maxTime := 60
+	timeOut := maxTime * 60 // Bacalhau timeout is in seconds, so we need to multiply by 60
 	memory := "12gb"
 	gpu := "1"
 	networkFlag := true
-	job, err := CreateBacalhauJob(cid, container, cmd, 12, true, networkFlag, []string{})
+	job, err := CreateBacalhauJob(cid, container, cmd, 60, 12, true, networkFlag, []string{})
 	if err != nil {
 		t.Fatalf(fmt.Sprint(err))
+	}
+	if job.Spec.Timeout != float64(timeOut) {
+		t.Errorf("got = %f; wanted %d", job.Spec.Timeout, timeOut)
 	}
 	if job.Spec.Resources.Memory != memory {
 		t.Errorf("got = %s; wanted %s", job.Spec.Resources.Memory, memory)

--- a/internal/ipwl/ipwl.go
+++ b/internal/ipwl/ipwl.go
@@ -157,7 +157,7 @@ func processIOTask(ioEntry IO, index, maxTime int, jobDir, ioJsonPath string, re
 		memory = *toolConfig.MemoryGB
 	}
 
-	bacalhauJob, err := bacalhau.CreateBacalhauJob(cid, toolConfig.DockerPull, cmd, memory, toolConfig.GpuBool, toolConfig.NetworkBool, annotations)
+	bacalhauJob, err := bacalhau.CreateBacalhauJob(cid, toolConfig.DockerPull, cmd, maxTime, memory, toolConfig.GpuBool, toolConfig.NetworkBool, annotations)
 	if err != nil {
 		updateIOWithError(ioJsonPath, index, err, fileMutex)
 		return fmt.Errorf("error creating Bacalhau job: %w", err)


### PR DESCRIPTION
## Summary

This is a sister PR to https://github.com/labdao/plex/pull/633. 

In the previous PR, the `maxTime` flag updates the time plex (client-side) waits for a Bacalhau job to complete. However, the Bacalhau job spec defaults to a timeout of 1800 sec (30 min).

This change connects the `maxTime` flag to Bacalhau's `Job.Spec.Timeout` value. Now `Job.Spec.Timeout` aligns with plex max wait time for job completion.

## Example

Initialize a diffdock job, which generally takes 10+ min.
```
./plex init -t tools/diffdock.json -i '{"protein": ["testdata/binding/pdbbind_processed_size1/6d08/6d08_protein_processed.pdb"], "small_molecule": ["testdata/binding/pdbbind_processed_size1/6d08/6d08_ligand.sdf"]}' --scatteringMethod=crossProduct                            
Plex version (v0.10.2) up to date.
Pinned IO JSON CID: QmaAZVjACY5bS2eNnvCqYRGxAXDgL4W7WYAuDENKYs3Nbp
```
Set `maxTime` flag to 1 min.
```
./plex run -i QmaAZVjACY5bS2eNnvCqYRGxAXDgL4W7WYAuDENKYs3Nbp -m 1 -a test
Plex version (v0.10.2) up to date.
Created working directory:  /Users/aakaash/Desktop/code/OPENLAB/plex/jobs/c602e946-fb2c-4dea-b60a-aaf272540c9d
Initialized IO file at:  /Users/aakaash/Desktop/code/OPENLAB/plex/jobs/c602e946-fb2c-4dea-b60a-aaf272540c9d/io.json
Processing IO Entries
Starting to process IO entry 0 
Job running...
Bacalhau job id: 0b29d97f-021a-4cbd-b5ad-3bab9b807a09 
Error processing IO entry 0 
error getting Bacalhau job results: bacalhau job did not finish within the expected time (~1 min); please check the job status manually with `bacalhau describe 0b29d97f-021a-4cbd-b5ad-3bab9b807a09`
Finished processing, results written to /Users/aakaash/Desktop/code/OPENLAB/plex/jobs/c602e946-fb2c-4dea-b60a-aaf272540c9d/io.json
Completed IO JSON CID: QmXpgknt7B1XDkiU9V66PDdx5jkNXYcRdcme4NSRxFy5st
```
Expected behavior of a job timeout occurs.