### PR TITLE
`PlexRun` refactored : now `RunIO` and lives in ipwl package

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -71,7 +71,7 @@ var initCmd = &cobra.Command{
 		}
 
 		if autoRun {
-			_, _, err := PlexRun(cid, outputDir, verbose, showAnimation, maxTime, concurrency, *annotationsForAutoRun)
+			_, _, err := ipwl.RunIO(cid, outputDir, verbose, showAnimation, maxTime, concurrency, *annotationsForAutoRun)
 			if err != nil {
 				fmt.Println("Error:", err)
 				os.Exit(1)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -31,7 +31,7 @@ var upgradeCmd = &cobra.Command{
 }
 
 const (
-	CurrentPlexVersion = "v0.10.3"
+	CurrentPlexVersion = "v0.10.4"
 	ReleaseURL         = "https://api.github.com/repos/labdao/plex/releases/latest"
 	ToolsURL           = "https://api.github.com/repos/labdao/plex/contents/tools?ref=main"
 )

--- a/gateway/handlers/jobs.go
+++ b/gateway/handlers/jobs.go
@@ -77,10 +77,38 @@ func InitJobHandler(db *gorm.DB) http.HandlerFunc {
 	}
 }
 
-func RunJobHandler() {
-	// log that this function is being hit
-	fmt.Print("RunJobHandler hit")
-}
+// func RunJobHandler(db *gorm.DB) http.HandlerFunc {
+// 	return func(w http.ResponseWriter, r *http.Request) {
+// 		if err := utils.CheckRequestMethod(r, http.MethodPost); err != nil {
+// 			utils.SendJSONError(w, err.Error(), http.StatusBadRequest)
+// 			return
+// 		}
+
+// 		var requestData struct {
+// 			IoJsonCid   string   `json:"ioJsonCid"`
+// 			OutputDir   string   `json:"outputDir"`
+// 			Annotations []string `json:"annotations"`
+// 		}
+
+// 		if err := utils.ReadRequestBody(r, &requestData); err != nil {
+// 			http.Error(w, "Error parsing request body", http.StatusBadRequest)
+// 			return
+// 		}
+
+// 		completedIoJsonCid, ioJsonPath, err := PlexRun(requestData.IoJsonCid, requestData.OutputDir, requestData.Annotations)
+// 		if err != nil {
+// 			http.Error(w, fmt.Sprintf("Error running job: %v", err), http.StatusInternalServerError)
+// 			return
+// 		}
+
+// 		responseData := map[string]string{
+// 			"completedIoJsonCid": completedIoJsonCid,
+// 			"ioJsonPath":         ioJsonPath,
+// 		}
+
+// 		utils.SendJSONResponse(w, responseData)
+// 	}
+// }
 
 func GetJobHandler(db *gorm.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/gateway/handlers/jobs.go
+++ b/gateway/handlers/jobs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -77,38 +78,44 @@ func InitJobHandler(db *gorm.DB) http.HandlerFunc {
 	}
 }
 
-// func RunJobHandler(db *gorm.DB) http.HandlerFunc {
-// 	return func(w http.ResponseWriter, r *http.Request) {
-// 		if err := utils.CheckRequestMethod(r, http.MethodPost); err != nil {
-// 			utils.SendJSONError(w, err.Error(), http.StatusBadRequest)
-// 			return
-// 		}
+func RunJobHandler(db *gorm.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := utils.CheckRequestMethod(r, http.MethodPost); err != nil {
+			utils.SendJSONError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 
-// 		var requestData struct {
-// 			IoJsonCid   string   `json:"ioJsonCid"`
-// 			OutputDir   string   `json:"outputDir"`
-// 			Annotations []string `json:"annotations"`
-// 		}
+		var requestData struct {
+			IoJsonCid   string   `json:"ioJsonCid"`
+			Annotations []string `json:"annotations"`
+		}
 
-// 		if err := utils.ReadRequestBody(r, &requestData); err != nil {
-// 			http.Error(w, "Error parsing request body", http.StatusBadRequest)
-// 			return
-// 		}
+		if err := utils.ReadRequestBody(r, &requestData); err != nil {
+			http.Error(w, "Error parsing request body", http.StatusBadRequest)
+			return
+		}
 
-// 		completedIoJsonCid, ioJsonPath, err := PlexRun(requestData.IoJsonCid, requestData.OutputDir, requestData.Annotations)
-// 		if err != nil {
-// 			http.Error(w, fmt.Sprintf("Error running job: %v", err), http.StatusInternalServerError)
-// 			return
-// 		}
+		tempDir, err := ioutil.TempDir("", "job")
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Error creating temporary directory: %v", err), http.StatusInternalServerError)
+			return
+		}
+		defer os.RemoveAll(tempDir)
 
-// 		responseData := map[string]string{
-// 			"completedIoJsonCid": completedIoJsonCid,
-// 			"ioJsonPath":         ioJsonPath,
-// 		}
+		completedIoJsonCid, ioJsonPath, err := ipwl.RunIO(requestData.IoJsonCid, requestData.OutputDir, false, false, 60, 1, requestData.Annotations)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Error running job: %v", err), http.StatusInternalServerError)
+			return
+		}
 
-// 		utils.SendJSONResponse(w, responseData)
-// 	}
-// }
+		responseData := map[string]string{
+			"completedIoJsonCid": completedIoJsonCid,
+			"ioJsonPath":         ioJsonPath,
+		}
+
+		utils.SendJSONResponse(w, responseData)
+	}
+}
 
 func GetJobHandler(db *gorm.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/gateway/server/server.go
+++ b/gateway/server/server.go
@@ -36,7 +36,7 @@ func NewServer(db *gorm.DB) *mux.Router {
 	router.HandleFunc("/init-job", handlers.InitJobHandler(db)).Methods("POST")
 	router.HandleFunc("/get-jobs", handlers.GetJobsHandler(db)).Methods("GET")
 	router.HandleFunc("/get-jobs/{cid}", handlers.GetJobHandler(db)).Methods("GET")
-	// router.HandleFunc("/run-job", handlers.RunJobHandler(db)).Methods("POST")
+	router.HandleFunc("/run-job", handlers.RunJobHandler(db)).Methods("POST")
 
 	return router
 }

--- a/internal/ipwl/ipwl.go
+++ b/internal/ipwl/ipwl.go
@@ -6,15 +6,74 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/labdao/plex/internal/bacalhau"
 	"github.com/labdao/plex/internal/ipfs"
 )
 
 var errOutputPathEmpty = errors.New("output file path is empty, still waiting")
+
+func RunIO(ioJsonCid, outputDir string, verbose, showAnimation bool, maxTime, concurrency int, annotations []string) (completedIoJsonCid, ioJsonPath string, err error) {
+	id := uuid.New()
+	var cwd string
+	if outputDir != "" {
+		absPath, err := filepath.Abs(outputDir)
+		if err != nil {
+			return completedIoJsonCid, ioJsonPath, err
+		}
+		cwd = absPath
+	} else {
+		cwd, err = os.Getwd()
+		if err != nil {
+			return completedIoJsonCid, ioJsonPath, err
+		}
+		cwd = path.Join(cwd, "jobs")
+	}
+	workDirPath := path.Join(cwd, id.String())
+	err = os.MkdirAll(workDirPath, 0755)
+	if err != nil {
+		return completedIoJsonCid, ioJsonPath, err
+	}
+	fmt.Println("Created working directory:", workDirPath)
+
+	ioJsonPath = path.Join(workDirPath, "io.json")
+	err = ipfs.DownloadFileContents(ioJsonCid, ioJsonPath)
+	if err != nil {
+		return completedIoJsonCid, ioJsonPath, err
+	}
+	fmt.Println("Initialized IO file at:", ioJsonPath)
+
+	userID, err := ExtractUserIDFromIOJson(ioJsonPath)
+	if err != nil {
+		return completedIoJsonCid, ioJsonPath, err
+	}
+
+	if userID != "" && !ContainsUserIdAnnotation(annotations) {
+		annotations = append(annotations, fmt.Sprintf("userId=%s", userID))
+	}
+
+	if maxTime > 60 {
+		fmt.Println("Error: maxTime cannot exceed 60 minutes")
+		os.Exit(1)
+	}
+
+	retry := false
+	fmt.Println("Processing IO Entries")
+	ProcessIOList(workDirPath, ioJsonPath, retry, verbose, showAnimation, maxTime, concurrency, annotations)
+	fmt.Printf("Finished processing, results written to %s\n", ioJsonPath)
+	completedIoJsonCid, err = ipfs.PinFile(ioJsonPath)
+	if err != nil {
+		return completedIoJsonCid, ioJsonPath, err
+	}
+
+	fmt.Println("Completed IO JSON CID:", completedIoJsonCid)
+	return completedIoJsonCid, ioJsonPath, nil
+}
 
 func ProcessIOList(jobDir, ioJsonPath string, retry, verbose, showAnimation bool, maxTime, maxConcurrency int, annotations []string) {
 	// Use a buffered channel as a semaphore to limit the number of concurrent tasks


### PR DESCRIPTION
## Summary

`PlexRun` logic has been moved to the ipwl package for gateway functionality.

This will make it easier to complete the `RunJobHandler` functionality in the gateway.

Should be ready for a binary upgrade v0.10.4. After binary upgrade, `go.mod` file in gateway should be updated to specify requiring `github.com/labdao/plex v0.10.4`

## Steps to Test

```
./plex init -t QmZWYpZXsrbtzvBCHngh4YEgME5djnV5EedyTpc8DrK7k2 -i '{"protein": ["QmUWCBTqbRaKkPXQ3M14NkUuM4TEwfhVfrqLNoBB7syyyd/7n9g.pdb"], "small_molecule": ["QmViB4EnKX6PXd77WYSgMDMq9ZMX14peu3ZNoVV1LHUZwS/ZINC000019632618.sdf"]}' --scatteringMethod=dotProduct --autoRun=true -a test
```

**Expected behavior:** should receive a completed IO JSON CID.