### PR TITLE
see if new swarm setting works

### DIFF
--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -3,6 +3,7 @@ package bacalhau
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"github.com/bacalhau-project/bacalhau/pkg/model"
 	"github.com/bacalhau-project/bacalhau/pkg/publicapi/client"
 	"github.com/bacalhau-project/bacalhau/pkg/system"
+	"gopkg.in/yaml.v3"
 )
 
 func GetBacalhauApiHost() string {
@@ -115,6 +117,46 @@ func CreateBacalhauJob(cid, container, cmd, selector string, maxTime, memory int
 	return job, err
 }
 
+// Define a simplified struct that only captures the SwarmAddresses field
+type Config struct {
+	Node struct {
+		IPFS struct {
+			SwarmAddresses []string `yaml:"SwarmAddresses"`
+		} `yaml:"IPFS"`
+	}
+}
+
+func modifySwarmAddresses(filePath string, newAddresses []string) error {
+	// Read YAML from file
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("error reading from file: %v", err)
+	}
+
+	var config Config
+
+	// Parse the YAML into the struct
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return fmt.Errorf("error parsing YAML: %v", err)
+	}
+
+	// Overwrite the SwarmAddresses values
+	config.Node.IPFS.SwarmAddresses = newAddresses
+
+	// Marshal the struct back to YAML
+	updatedYAML, err := yaml.Marshal(&config)
+	if err != nil {
+		return fmt.Errorf("error marshaling to YAML: %v", err)
+	}
+
+	// Save the updated YAML back to the file
+	if err := ioutil.WriteFile(filePath, updatedYAML, 0644); err != nil {
+		return fmt.Errorf("error writing to file: %v", err)
+	}
+
+	return nil
+}
+
 func CreateBacalhauClient() (*client.APIClient, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -126,14 +168,17 @@ func CreateBacalhauClient() (*client.APIClient, error) {
 		return nil, err
 	}
 	if os.Getenv("BACALHAU_IPFS_SWARM_ADDRESSES") != "" {
-		bacalhauConfig.Node.IPFS.SwarmAddresses = []string{os.Getenv("BACALHAU_IPFS_SWARM_ADDRESSES")}
+		swarmAddresses := []string{os.Getenv("BACALHAU_IPFS_SWARM_ADDRESSES")}
+		bacalhauConfig.Node.IPFS.SwarmAddresses = swarmAddresses
+
+		// need to write config because Bacalhau Downloader re-reads from config file not the in memory config
+		if err := modifySwarmAddresses(filepath.Join(bacalhauConfigDirPath, "config.yaml"), swarmAddresses); err != nil {
+			return nil, err
+		}
 	}
 	config.SetUserKey(filepath.Join(bacalhauConfigDirPath, "user_id.pem"))
 	config.SetLibp2pKey(filepath.Join(bacalhauConfigDirPath, "libp2p_private_key"))
 	config.Set(bacalhauConfig)
-
-	// need to write config because Bacalhau Downloader re-reads from config file not the in memory config
-	config.WriteConfig(filepath.Join(bacalhauConfigDirPath, "config.yaml"))
 
 	_, err = config.Init(bacalhauConfig, bacalhauConfigDirPath, "config", "yaml")
 	if err != nil {

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -121,12 +121,12 @@ func CreateBacalhauClient() (*client.APIClient, error) {
 		return nil, err
 	}
 	bacalhauConfigDirPath := filepath.Join(home, ".bacalhau")
-	config.SetUserKey(filepath.Join(bacalhauConfigDirPath, "user_id.pem"))
-	config.SetLibp2pKey(filepath.Join(bacalhauConfigDirPath, "libp2p_private_key"))
 	defaultConfig := config.ForEnvironment()
 	if os.Getenv("BACALHAU_IPFS_SWARM_ADDRESSES") != "" {
 		defaultConfig.Node.IPFS.SwarmAddresses = []string{os.Getenv("BACALHAU_IPFS_SWARM_ADDRESSES")}
 	}
+	config.SetUserKey(filepath.Join(bacalhauConfigDirPath, "user_id.pem"))
+	config.SetLibp2pKey(filepath.Join(bacalhauConfigDirPath, "libp2p_private_key"))
 	config.Set(defaultConfig)
 	_, err = config.Init(defaultConfig, filepath.Join(home, ".bacalhau"), "config", "yaml")
 	if err != nil {

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -121,14 +121,17 @@ func CreateBacalhauClient() (*client.APIClient, error) {
 		return nil, err
 	}
 	bacalhauConfigDirPath := filepath.Join(home, ".bacalhau")
-	defaultConfig := config.ForEnvironment()
+	bacalhauConfig, err := config.Load(bacalhauConfigDirPath, "config", "yaml")
+	if err != nil {
+		return nil, err
+	}
 	if os.Getenv("BACALHAU_IPFS_SWARM_ADDRESSES") != "" {
-		defaultConfig.Node.IPFS.SwarmAddresses = []string{os.Getenv("BACALHAU_IPFS_SWARM_ADDRESSES")}
+		bacalhauConfig.Node.IPFS.SwarmAddresses = []string{os.Getenv("BACALHAU_IPFS_SWARM_ADDRESSES")}
 	}
 	config.SetUserKey(filepath.Join(bacalhauConfigDirPath, "user_id.pem"))
 	config.SetLibp2pKey(filepath.Join(bacalhauConfigDirPath, "libp2p_private_key"))
-	config.Set(defaultConfig)
-	_, err = config.Init(defaultConfig, filepath.Join(home, ".bacalhau"), "config", "yaml")
+	config.Set(bacalhauConfig)
+	_, err = config.Init(bacalhauConfig, bacalhauConfigDirPath, "config", "yaml")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -131,6 +131,10 @@ func CreateBacalhauClient() (*client.APIClient, error) {
 	config.SetUserKey(filepath.Join(bacalhauConfigDirPath, "user_id.pem"))
 	config.SetLibp2pKey(filepath.Join(bacalhauConfigDirPath, "libp2p_private_key"))
 	config.Set(bacalhauConfig)
+
+	// need to write config because Bacalhau Downloader re-reads from config file not the in memory config
+	config.WriteConfig(filepath.Join(bacalhauConfigDirPath, "config.yaml"))
+
 	_, err = config.Init(bacalhauConfig, bacalhauConfigDirPath, "config", "yaml")
 	if err != nil {
 		return nil, err

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -127,6 +127,7 @@ func CreateBacalhauClient() (*client.APIClient, error) {
 	if os.Getenv("BACALHAU_IPFS_SWARM_ADDRESSES") != "" {
 		defaultConfig.Node.IPFS.SwarmAddresses = []string{os.Getenv("BACALHAU_IPFS_SWARM_ADDRESSES")}
 	}
+	config.Set(defaultConfig)
 	_, err = config.Init(defaultConfig, filepath.Join(home, ".bacalhau"), "config", "yaml")
 	if err != nil {
 		return nil, err

--- a/internal/ipfs/ipfs.go
+++ b/internal/ipfs/ipfs.go
@@ -113,11 +113,8 @@ func DownloadToDirectory(cid, directory string) error {
 	ipfsNodeUrl := DeriveIpfsNodeUrl()
 	sh := shell.NewShell(ipfsNodeUrl)
 
-	// Construct the full directory path where the CID content will be downloaded
-	downloadPath := path.Join(directory, cid)
-
 	// Use the Get method to download the file or directory with the specified CID
-	err := sh.Get(cid, downloadPath)
+	err := sh.Get(cid, directory)
 	if err != nil {
 		return err
 	}

--- a/internal/ipwl/ipwl.go
+++ b/internal/ipwl/ipwl.go
@@ -311,12 +311,6 @@ func processIOTask(ioEntry IO, index, maxTime int, jobDir, ioJsonPath, selector 
 		return fmt.Errorf("error downloading Bacalhau results: %w", err)
 	}
 
-	// err = bacalhau.DownloadBacalhauResults(outputsDirPath, submittedJob, results)
-	// if err != nil {
-	//	updateIOWithError(ioJsonPath, index, err, fileMutex)
-	//	return fmt.Errorf("error downloading Bacalhau results: %w", err)
-	//}
-
 	if verbose {
 		fmt.Println("Cleaning Bacalhau job")
 	}

--- a/internal/ipwl/ipwl.go
+++ b/internal/ipwl/ipwl.go
@@ -300,11 +300,22 @@ func processIOTask(ioEntry IO, index, maxTime int, jobDir, ioJsonPath, selector 
 		fmt.Println("Downloading Bacalhau job")
 		fmt.Printf("Output dir of %s \n", outputsDirPath)
 	}
-	err = bacalhau.DownloadBacalhauResults(outputsDirPath, submittedJob, results)
+
+	for _, result := range results {
+		fmt.Printf("Downloading result %s to %s \n", result.Data.CID, outputsDirPath)
+		err = ipfs.DownloadToDirectory(result.Data.CID, outputsDirPath)
+	}
+
 	if err != nil {
 		updateIOWithError(ioJsonPath, index, err, fileMutex)
 		return fmt.Errorf("error downloading Bacalhau results: %w", err)
 	}
+
+	// err = bacalhau.DownloadBacalhauResults(outputsDirPath, submittedJob, results)
+	// if err != nil {
+	//	updateIOWithError(ioJsonPath, index, err, fileMutex)
+	//	return fmt.Errorf("error downloading Bacalhau results: %w", err)
+	//}
 
 	if verbose {
 		fmt.Println("Cleaning Bacalhau job")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Description

Private CI is not working because Bacalhau depreciated the old way we used to set `BACALHAU_IPFS_SWARM_ADDRESSES`

This PR fixes it by setting `BACALHAU_IPFS_SWARM_ADDRESSES` during Bacalhau client creation. It also uses IPFS directly for result downloads instead of the Bacalhau wrapper. This is because the Bacalhau IPFS Downloader doesn't correctly use the `BACALHAU_IPFS_SWARM_ADDRESSES` setting.

Other small changes
- `CreateBacalhauClient` returns an error instead of panicking
- `ipfs.DownloadToDirectory` uses the directory argument and doesn't namespace the directory with the CID. `ipfs.DownloadToDirectory` was not used anywhere in the codebase when I made this change.

## Related Tickets & Documents

[Linear Ticket](https://linear.app/convexitylabs/issue/LAB-699/bacalhau-swarm-config-commented-out)

[Bacalhau Slack](https://bacalhauproject.slack.com/archives/C055U60AJKE/p1697727072398019?thread_ts=1697722410.547569&cid=C055U60AJKE)

## Steps to Test

Hope the CI passes.

## Relevant GIF 

<img width="689" alt="Screenshot 2023-10-23 at 9 05 54 AM" src="https://github.com/labdao/plex/assets/9427089/7f3dd65c-981f-456f-a677-2e0d963f05d9">


