### PR TITLE
723 lab 728 lab 721 web socket security error in production

### DIFF
--- a/frontend/app/job/detail/[jobID]/LogViewer.tsx
+++ b/frontend/app/job/detail/[jobID]/LogViewer.tsx
@@ -15,11 +15,12 @@ const LogViewer = () => {
 
   useEffect(() => {
     setLogs('')
-    // remove http:// or https:// from backendUrl for websocket
-    let formattedBackendUrl = backendUrl().replace('http://', '')
-    formattedBackendUrl = formattedBackendUrl.replace('https://', '')
+
+    let formattedBackendUrl = backendUrl().replace('http://', '').replace('https://', '');
+    let wsProtocol = backendUrl().startsWith('https://') ? 'wss' : 'ws';
+  
     console.log(formattedBackendUrl)
-    const ws = new WebSocket(`ws://${formattedBackendUrl}/jobs/${job.BacalhauJobID}/logs`)
+    const ws = new WebSocket(`${wsProtocol}://${formattedBackendUrl}/jobs/${job.BacalhauJobID}/logs`)
 
     ws.onopen = () => {
       console.log('connected')

--- a/tools/equibind/equibind_gateway.json
+++ b/tools/equibind/equibind_gateway.json
@@ -18,6 +18,7 @@
   "dockerPull": "ghcr.io/labdao/equibind:main@sha256:21a381d9ab1ff047565685044569c8536a55e489c9531326498b28d6b3cc244f",
   "gpuBool": false,
   "networkBool": false,
+  "memoryGB": 5,
   "inputs": {
     "protein": {
       "type": "File",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

-  🐛 Bug Fix

## Description
This error is getting caused by using ws instead of wss in an https enviroment.

<img width="1405" alt="Screenshot 2023-10-23 at 4 00 34 PM" src="https://github.com/labdao/plex/assets/9427089/d539dfec-6cb1-4687-ae51-bfffb15e3260">

This PR fixes it by adding wss when the url is https. Also, added the 5mb req to the equibind gateway tool.

## Related Tickets & Documents

[Linear Ticket](https://linear.app/convexitylabs/issue/LAB-721/web-socket-security-error-in-production)

## Steps to Test

Uploading the new equibind gateway file and equibind test files should run against any docker compose full stack env. Logs don't stream until Bacalhau Job starts, so just keep re-clicking the update button if a web socket closed error message appears.

<img width="632" alt="Screenshot 2023-10-23 at 3 57 43 PM" src="https://github.com/labdao/plex/assets/9427089/d899f4e4-d7a5-42a9-919f-edd3c9718b62">

Not sure how to test the `wss` portion without deploying. 


## Relevant GIF 

<img width="484" alt="Screenshot 2023-10-23 at 4 09 18 PM" src="https://github.com/labdao/plex/assets/9427089/715b1cf2-b778-494f-8ebd-da6de6a75b61">
