### PR TITLE
add colabfold mini to gateway

### DIFF
--- a/tools/colabfold/colabfold-mini-gateway.json
+++ b/tools/colabfold/colabfold-mini-gateway.json
@@ -1,0 +1,33 @@
+{
+    "class": "CommandLineTool",
+    "name": "colabfold-miniV2 gateway 12GB memory",
+    "description": "Protein folding prediction using Colabfold (mini settings)",
+    "author": "",
+    "baseCommand": ["/bin/bash", "-c"],
+    "arguments": [
+      "colabfold_batch --templates --max-msa 32:64 --num-recycle 1 /inputs/sequence /outputs;"
+    ],
+    "dockerPull": "public.ecr.aws/p7l9w5o7/colabfold:latest",
+    "gpuBool": true,
+    "networkBool": true,
+    "memoryGB": 12,
+    "inputs": {
+      "sequence": {
+        "type": "File",
+        "item": "",
+        "glob": ["*.fasta"]
+      }
+    },
+    "outputs": {
+      "best_folded_protein": {
+        "type": "File",
+        "item": "",
+        "glob": ["*rank_1*.pdb"]
+      },
+      "all_folded_proteins": {
+        "type": "Array",
+        "item": "File",
+        "glob": ["*rank*.pdb"]
+      }
+    }
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

-  🎮 Feature
-  🐛 Bug Fix

## Description

Originally this PR was to support non file parameters. However, since all outputs have to be files and since the scienctific community is using config files, I think it is best to only support file inputs. In the future we can support type defining config files in the Model (formerly known as Tool) json. I added a Colabfold mini that works on the gateway.

## Related Tickets & Documents

[Linear Ticket](https://linear.app/convexitylabs/issue/LAB-689/support-non-file-parameters)

[Colabfold Succesful Experiment](https://app.prod.labdao.xyz/job/detail/a04a2272-d257-48c7-a144-bda814a42165)

## Steps to Test

Run the following Experiment (formerly known as Flow) on [Prod](https://app.prod.labdao.xyz/), takes ~20 minutes.

<img width="437" alt="Screenshot 2023-10-24 at 9 36 15 AM" src="https://github.com/labdao/plex/assets/9427089/69451590-c15c-4774-8f82-d98f8b8041da">


## Relevant GIF 

<img width="602" alt="Screenshot 2023-10-24 at 5 10 40 PM" src="https://github.com/labdao/plex/assets/9427089/5506cb15-9e7f-4f9b-8758-6919c333c250">
