### PR TITLE
adding sha as tag

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,12 +6,12 @@ name: backend
 on:
   push:
     branches: ["main"]
-    paths-ignore:
-      - 'docs/**'
-      - 'infrastructure/**'
     # Pattern matched against refs/tags
     tags:
       - '**'
+    paths-ignore:
+      - 'docs/**'
+      - 'infrastructure/**'
 
   pull_request:
     branches: ["main"]

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,12 +6,12 @@ name: frontend
 on:
   push:
     branches: ["main"]
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend.yml'
     # Pattern matched against refs/tags
     tags:
       - '**'
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend.yml'
 
   pull_request:
     branches: ["main"]

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -6,12 +6,12 @@ name: ipfs
 on:
   push:
     branches: ["main"]
-    paths:
-      - 'docker/images/ipfs/**'
-      - '.github/workflows/ipfs.yml'
     # Pattern matched against refs/tags
     tags:
       - '**'
+    paths:
+      - 'docker/images/ipfs/**'
+      - '.github/workflows/ipfs.yml'
 
   pull_request:
     branches: ["main"]

--- a/.github/workflows/receptor.yml
+++ b/.github/workflows/receptor.yml
@@ -6,12 +6,12 @@ name: receptor
 on:
   push:
     branches: ["main"]
-    paths:
-      - 'receptor/**'
-      - '.github/workflows/receptor.yml'
     # Pattern matched against refs/tags
     tags:
       - '**'
+    paths:
+      - 'receptor/**'
+      - '.github/workflows/receptor.yml'
   pull_request:
     branches: ["main"]
     paths:


### PR DESCRIPTION
Using sha as version info for images. This ensures that when new image with same tag e.g., main is pushed, there's still main-sha**` image that we could use ensuring that image is available.