### PR TITLE
[LAB-743] increase docker pull concurrent limit

### DIFF
--- a/infrastructure/ansible/tasks/install_docker_tasks.yaml
+++ b/infrastructure/ansible/tasks/install_docker_tasks.yaml
@@ -32,3 +32,21 @@
       - containerd.io
       - docker-compose-plugin
     update_cache: true
+
+- name: Push custom docker daemon config
+  vars:
+    docker_config:
+      # data-root: /var/lib/docker
+      # pidfile: /var/run/docker.pid
+      live-restore: true
+      max-concurrent-downloads: 20
+      max-download-attempts: 5
+      storage-driver: overlay2
+  become: true
+  ansible.builtin.copy:
+    content: "{{ docker_config | to_json(indent=2, sort_keys=True) }}"
+    dest: /etc/docker/daemon.json
+    owner: root
+    group: root
+    mode: "0400"
+  notify: Restart docker


### PR DESCRIPTION
## What type of PR is this? 

- 🔋 Optimization

## Description

This PR is to increase docker `max-concurrent-downloads` to 20 allowing faster download of containers/