### PR TITLE
[LAB-751] fixing docker log streaming.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,13 +35,16 @@ services:
     image: "ghcr.io/bacalhau-project/bacalhau:v${BACALHAU_VERSION:-1.1.2}"
     hostname: compute
     user: root
-    command: serve --ipfs-connect '/dns4/ipfs/tcp/5001' --node-type compute --labels "owner=labdao" --private-internal-ipfs=false --peer "/dns4/requester/tcp/1234/http" --job-selection-probe-http "http://receptor:8080/judge" --max-job-execution-timeout "24h" --job-selection-accept-networked --job-selection-data-locality anywhere
+    command: serve --ipfs-connect '/dns4/ipfs/tcp/5001' --node-type compute --labels "owner=labdao" --private-internal-ipfs=false --peer "/dns4/requester/tcp/1234/http" --job-selection-probe-http "http://receptor:8080/judge" --max-job-execution-timeout "24h" --job-selection-accept-networked --job-selection-data-locality anywhere --port 2234 --swarm-port 2235
     environment:
       LOG_LEVEL: trace
       DOCKER_DEFAULT_PLATFORM: linux/amd64
       # Keep containers around - I think
       KEEP_STACK: "true"
       BACALHAU_DIR: /tmp/bacalhau
+    ports:
+      - 2234:2234
+      - 2235:2235
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp:/tmp
@@ -61,7 +64,7 @@ services:
       compute:
         condition: service_started
     healthcheck:
-      test: curl -f http://compute:1234/api/v1/healthz
+      test: curl -f http://compute:2234/api/v1/healthz
       interval: 10s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
## What type of PR is this? 

- 🐛 Bug Fix

## Description
The log streaming happens directly from compute node.

with both requester and compute running locally within docker compose listening on the same port causes
peer id conflict

## Relevant GIF 

![](https://media.giphy.com/media/zhJR6HbK4fthC/giphy.gif)