### PR TITLE
[LAB-853] Ability to support multiple tool config per tool

### DIFF
--- a/tools/colabdesign/colabdesign.json
+++ b/tools/colabdesign/colabdesign.json
@@ -3,10 +3,7 @@
   "name": "colabdesign-dev",
   "description": "one-pot design of protein backbones and sequences",
   "author": "",
-  "baseCommand": [
-    "/bin/bash",
-    "-c"
-  ],
+  "baseCommand": ["/bin/bash", "-c"],
   "arguments": [
     "mv /inputs/*.pdb /inputs/target_protein.pdb && mv /inputs/config/*.yaml /inputs/config.yaml;",
     "ls /inputs;",
@@ -23,46 +20,34 @@
     "protein": {
       "type": "File",
       "item": "",
-      "glob": [
-        "*.pdb"
-      ]
+      "glob": ["*.pdb"]
     },
     "config": {
       "type": "File",
       "item": "",
-      "glob": [
-        "*.yaml"
-      ]
+      "glob": ["*.yaml"]
     }
   },
   "outputs": {
     "best_design": {
       "type": "File",
       "item": "",
-      "glob": [
-        "best.pdb"
-      ]
+      "glob": ["best.pdb"]
     },
     "design_scores": {
       "type": "File",
       "item": "",
-      "glob": [
-        "mpnn_results.csv"
-      ]
+      "glob": ["mpnn_results.csv"]
     },
     "design_sequences": {
       "type": "File",
       "item": "",
-      "glob": [
-        "design.fasta"
-      ]
+      "glob": ["design.fasta"]
     },
     "compressed_designs": {
       "type": "Array",
       "item": "File",
-      "glob": [
-        "*.zip"
-      ]
+      "glob": ["*.zip"]
     }
   }
 }


### PR DESCRIPTION
This PR updates the tool manifest upload workflow to support multiple tool manifests per tool directory.
Previous to this change you could only have one config per tool being read by this workflow.
Now using this workflow multiple config files can be uploaded.