### PR TITLE
Removed execution timeout from service

### DIFF
--- a/infrastructure/ansible/files/compute.service
+++ b/infrastructure/ansible/files/compute.service
@@ -19,7 +19,6 @@ ExecStart=bacalhau serve \
   --labels instance-id={{ ansible_ec2_instance_id }} \
 {% endif %}
   --job-selection-probe-http {{ receptor_url }} \
-  --max-job-execution-timeout "{{ bacalhau_max_job_execution_timeout | default('24h') }}" \
   --peer {{ requester_peer }} \
   --job-selection-accept-networked \
   --job-selection-data-locality anywhere


### PR DESCRIPTION
## What type of PR is this? 
- 🐛 Bug Fix

## Description
Missed last location where max-execution-timeout is set. Setting it to unlimited.