### PR TITLE
[WIP]: fix naked cid issue for generated datafiles

### DIFF
--- a/gateway/handlers/flows.go
+++ b/gateway/handlers/flows.go
@@ -166,6 +166,7 @@ func AddFlowHandler(db *gorm.DB) http.HandlerFunc {
 				BacalhauJobID: job.BacalhauJobId,
 				State:         job.State,
 				Error:         job.ErrMsg,
+				WalletAddress: walletAddress,
 				ToolID:        job.Tool.IPFS,
 				FlowID:        flowEntry.CID,
 			}

--- a/gateway/handlers/jobs.go
+++ b/gateway/handlers/jobs.go
@@ -233,10 +233,11 @@ func UpdateJobHandler(db *gorm.DB) http.HandlerFunc {
 						log.Println("Saving generated DataFile to DB with CID:", fileEntry["CID"])
 
 						dataFile = models.DataFile{
-							CID:       wrappedCid,
-							Filename:  fileName,
-							Tags:      []models.Tag{generatedTag, experimentTag, extensionTag},
-							Timestamp: time.Now(),
+							CID:           wrappedCid,
+							WalletAddress: job.WalletAddress,
+							Filename:      fileName,
+							Tags:          []models.Tag{generatedTag, experimentTag, extensionTag},
+							Timestamp:     time.Now(),
 						}
 
 						if err := db.Create(&dataFile).Error; err != nil {

--- a/gateway/handlers/jobs.go
+++ b/gateway/handlers/jobs.go
@@ -135,7 +135,7 @@ func UpdateJobHandler(db *gorm.DB) http.HandlerFunc {
 
 		if job.State == "completed" {
 			// we always only do one execution at the moment
-			fmt.Println("Job completed, getting output directory CID")
+			fmt.Println("Job completed, getting output directory CID...")
 			outputDirCID := updatedJob.State.Executions[0].PublishedResult.CID
 			outputFileEntries, err := ipfs.ListFilesInDirectory(outputDirCID)
 			if err != nil {

--- a/gateway/handlers/jobs.go
+++ b/gateway/handlers/jobs.go
@@ -163,7 +163,13 @@ func UpdateJobHandler(db *gorm.DB) http.HandlerFunc {
 					continue
 				}
 
-				wrappedCid, err := ipfs.WrapAndPinFile(fileEntry["CID"])
+				tempFilePath, err := ipfs.DownloadFileToTemp(fileEntry["CID"], fileEntry["filename"])
+				if err != nil {
+					http.Error(w, fmt.Sprintf("Error downloading file from IPFS: %v", err), http.StatusInternalServerError)
+					return
+				}
+
+				wrappedCid, err := ipfs.WrapAndPinFile(tempFilePath)
 				if err != nil {
 					http.Error(w, fmt.Sprintf("Error adding to IPFS: %v", err), http.StatusInternalServerError)
 					return


### PR DESCRIPTION
## What type of PR is this? 

- 🐛 Bug Fix

## Description

Generated datafiles from Experiments were previously being saved to the DB in a naked (unwrapped) state. This PR fixes this issue by wrapping output datafiles, pinning, then writing the wrapped CIDs to the DB.

This allows users to add the outputs of an Experiment as inputs to other Experiments