### PR TITLE
Update tools.yml with AF2 tool

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -73,6 +73,10 @@ jobs:
             - 'tools/protein-to-dna-icodon/**'
             - '.github/workflows/tools.yml'
             - '.github/workflows/docker.yml'
+          AF2:
+            - 'tools/AF2/**'
+            - '.github/workflows/tools.yml'
+            - '.github/workflows/docker.yml'
 
 
   tools:


### PR DESCRIPTION
I noticed that AF2 had not been added here. It was only added to the tools manifest.

## What type of PR is this? 
_Remove the categories that do not apply_

- 🐛 Bug Fix

## Description

added AF2 as a tool. No idea, why it was not added earlier.
