### PR TITLE
make frontend `arm64` platform build work

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,7 @@ ARG NEXT_PUBLIC_IPFS_GATEWAY_ENDPOINT
 # Install dependencies only when needed
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat python3 build-base
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager


### PR DESCRIPTION
Tested using on linux:
```
docker build -t test --platform linux/arm64 .
```

Users with mac can test using the same command without `--platform` flag.