### PR TITLE
LAB 1164 bacalhau 1.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY --from=bacalhau --chmod=755 /usr/local/bin/bacalhau /usr/local/bin/bacalhau
 
 # This creates config file needed by bacalhau golang client
 RUN /usr/local/bin/bacalhau version
+RUN /usr/local/bin/bacalhau config default > /root/.bacalhau/config.yaml
 
 ENV POSTGRES_PASSWORD=MAKE_UP_SOMETHING_RANDOM
 ENV POSTGRES_USER=labdao

--- a/infrastructure/ansible/files/compute.yaml
+++ b/infrastructure/ansible/files/compute.yaml
@@ -1,0 +1,10 @@
+---
+
+node:
+    compute:
+        capacity:
+            queueresourcelimits:
+                cpu: 0m
+                disk: 0 B
+                gpu: "0"
+                memory: 0 B

--- a/infrastructure/ansible/tasks/install_bacalhau_tasks.yaml
+++ b/infrastructure/ansible/tasks/install_bacalhau_tasks.yaml
@@ -102,11 +102,14 @@
     - name: Flush handler to ensure Bacalhau is running
       ansible.builtin.meta: flush_handlers
 
-    - name: Remove the config file if exists
+    - name: Deploy config file
       become: true
-      ansible.builtin.file:
-        path: /home/ubuntu/.bacalhau/config.yaml
-        state: absent
+      ansible.builtin.template:
+        src: "files/{{ bacalhau_node_type }}.yaml"
+        dest: /home/ubuntu/.bacalhau/config.yaml
+        owner: ubuntu
+        group: ubuntu
+        mode: "0644"
       notify:
         - Restart Bacalhau
 


### PR DESCRIPTION
- Updated for backend to work, generating config file using `bacalhau config` option.
- bacalhau client config file now only has enqueue limits which are set to `0` disabling the queuing mechanism.