### PR TITLE
Update tool endpoint

### DIFF
--- a/gateway/handlers/tools.go
+++ b/gateway/handlers/tools.go
@@ -207,6 +207,13 @@ func UpdateToolHandler(db *gorm.DB) http.HandlerFunc {
 			return
 		}
 
+		// Check if any rows were affected
+		if result.RowsAffected == 0 {
+			tx.Rollback() // Rollback the transaction as no update was performed
+			utils.SendJSONError(w, "Tool with the specified CID not found", http.StatusNotFound)
+			return
+		}
+
 		// Commit the transaction
 		if err := tx.Commit().Error; err != nil {
 			http.Error(w, fmt.Sprintf("Transaction commit error: %v", err), http.StatusInternalServerError)

--- a/gateway/lab-exchange-api-spec.json
+++ b/gateway/lab-exchange-api-spec.json
@@ -233,6 +233,128 @@
           }
         }
       },
+      "/update-tool/{cid}": {
+        "put": {
+          "operationId": "updateTool",
+          "summary": "Update Tool",
+          "parameters": [
+            {
+              "name": "cid",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "description": "The CID of the tool to update"
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "taskCategory": {
+                      "type": "string",
+                      "description": "The new task category for the tool"
+                    },
+                    "display": {
+                      "type": "boolean",
+                      "description": "Flag indicating whether the tool should be displayed"
+                    },
+                    "defaultTool": {
+                      "type": "boolean",
+                      "description": "Flag indicating whether the tool is the default tool for its category"
+                    }
+                  },
+                  "anyOf": [
+                    {
+                      "required": ["taskCategory"]
+                    },
+                    {
+                      "required": ["display"]
+                    },
+                    {
+                      "required": ["defaultTool"]
+                    }
+                  ],
+                  "minProperties": 1
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Tool updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Tool updated successfully"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request, such as no request body or invalid request body",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "examples": {
+                    "emptyRequestBody": {
+                      "value": {
+                        "message": "No valid fields provided for update"
+                      }
+                    },
+                    "invalidTaskCategory": {
+                      "value": {
+                        "message": "Task category not accepted"
+                      }
+                    },
+                    "dataTypeError": {
+                      "value": {
+                        "message": "Invalid request body: json: cannot unmarshal string into Go struct field .display of type bool"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "404": {
+              "description": "Tool with the specified CID not found",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string",
+                        "example": "Tool with the specified CID not found"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          }
+        }
+      },
       "/datafiles": {
         "post": {
           "operationId": "addDataFile",

--- a/gateway/server/server.go
+++ b/gateway/server/server.go
@@ -28,6 +28,7 @@ func NewServer(db *gorm.DB) *mux.Router {
 	router.HandleFunc("/tools", handlers.AddToolHandler(db)).Methods("POST")
 	router.HandleFunc("/tools/{cid}", handlers.GetToolHandler(db)).Methods("GET")
 	router.HandleFunc("/tools", handlers.ListToolsHandler(db)).Methods("GET")
+	router.HandleFunc("/update-tool/{cid}", handlers.UpdateToolHandler(db)).Methods("PUT")
 
 	router.HandleFunc("/datafiles", handlers.AddDataFileHandler(db)).Methods("POST")
 	router.HandleFunc("/datafiles/{cid}", handlers.GetDataFileHandler(db)).Methods("GET")

--- a/gateway/server/server.go
+++ b/gateway/server/server.go
@@ -28,7 +28,7 @@ func NewServer(db *gorm.DB) *mux.Router {
 	router.HandleFunc("/tools", handlers.AddToolHandler(db)).Methods("POST")
 	router.HandleFunc("/tools/{cid}", handlers.GetToolHandler(db)).Methods("GET")
 	router.HandleFunc("/tools", handlers.ListToolsHandler(db)).Methods("GET")
-	router.HandleFunc("/update-tool/{cid}", handlers.UpdateToolHandler(db)).Methods("PUT")
+	router.HandleFunc("/tools/{cid}", handlers.UpdateToolHandler(db)).Methods("PUT")
 
 	router.HandleFunc("/datafiles", handlers.AddDataFileHandler(db)).Methods("POST")
 	router.HandleFunc("/datafiles/{cid}", handlers.GetDataFileHandler(db)).Methods("GET")


### PR DESCRIPTION
## What type of PR is this? 
_Remove the categories that do not apply_

- 🎮 Feature
- 🍧 Refactor
- 🔋 Optimization

## Description

This endpoint is to update the tool on the 3 new columns added taskCategory, display, defaultTool.
The request body should contain JSON data with atleast one of the above, or 2 or all of the fields mentioned above for updating the tool.
The function validates the taskCategory field against a predefined set of accepted categories.

## Steps to Test

Example usage:
1. Updating the task category of a tool:
   PUT /tools/{cid}
   Request Body: {"taskCategory": "protein-folding"}

2. Updating the display status of a tool:
   PUT /tools/{cid}
   Request Body: {"display": true}

3. Updating both the task category and default tool status of a tool:
   PUT /tools/{cid}
   Request Body: {"taskCategory": "other-models", "defaultTool": true}

4. Attempting to update a tool with an invalid task category:
   PUT /tools/{cid}
   Request Body: {"taskCategory": "invalid-category"}
   Response: {"error": "Task category not accepted"}
