### PR TITLE
add a new capacity error message to catch

### DIFF
--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -230,7 +230,7 @@ func GetBacalhauJobState(jobId string) (*model.JobWithInfo, error) {
 }
 
 func JobFailedWithCapacityError(job *model.JobWithInfo) bool {
-	capacityErrorMessages := []string{"not enough capacity", "not enough nodes"}
+	capacityErrorMessages := []string{"not enough capacity", "not enough nodes", "does not have capacity"}
 	falseCapacityMessages := []string{"Could not inspect image", "node does not support the available image platforms"}
 	if len(job.State.Executions) > 0 {
 		fmt.Printf("Checking for capacity error, got error: %v\n", job.State.Executions[0].Status)


### PR DESCRIPTION
## What type of PR is this? 

- 🐛 Bug Fix

## Description

Jobs were not re-queuing with the status message:

```Status: 'this node does not have capacity to run the job```

Is not in the error message strings we were checking 

["not enough capacity", "not enough nodes"]

So I added:

"does not have capacity'

## Steps to test, kick off 3 or more conditions at once on app.prod.labdao.xyz

Before fix a few conditions would immediately would fail after capacity was met
<img width="1043" alt="Screenshot 2024-02-21 at 10 13 16 AM" src="https://github.com/labdao/plex/assets/9427089/0cd42bfc-c5c2-49ca-9678-aa654a0db8fb">


After fix conditions are waiting in the queue
<img width="1068" alt="Screenshot 2024-02-21 at 10 16 34 AM" src="https://github.com/labdao/plex/assets/9427089/9b850074-f8fd-46cb-970f-370b684990b6">



## Relevant GIF 

<img width="464" alt="Screenshot 2024-02-21 at 9 53 33 AM" src="https://github.com/labdao/plex/assets/9427089/164e8681-2bf8-4fe6-8d41-9dc692876645">
