### PR TITLE
use last instead of first bacalhau execution

### DIFF
--- a/gateway/utils/queue.go
+++ b/gateway/utils/queue.go
@@ -180,7 +180,8 @@ func processJob(jobID uint, db *gorm.DB) error {
 		} else if bacalhau.JobCompleted(bacalhauJob) {
 			fmt.Printf("Job %v , %v completed\n", job.ID, job.BacalhauJobID)
 			if len(bacalhauJob.State.Executions) > 0 {
-				return completeJobAndAddOutputFiles(&job, models.JobStateCompleted, bacalhauJob.State.Executions[0].PublishedResult.CID, db)
+				lastExecutionIndex := len(bacalhauJob.State.Executions) - 1
+				return completeJobAndAddOutputFiles(&job, models.JobStateCompleted, bacalhauJob.State.Executions[lastExecutionIndex].PublishedResult.CID, db)
 			}
 			return setJobStatus(&job, models.JobStateFailed, fmt.Sprintf("Output execution data lost for %v", job.BacalhauJobID), db)
 		} else if bacalhau.JobCancelled(bacalhauJob) {
@@ -220,7 +221,8 @@ func checkRunningJob(jobID uint, db *gorm.DB) error {
 	} else if bacalhau.JobCompleted(bacalhauJob) {
 		fmt.Printf("Job %v , %v completed, updating status and adding output files\n", job.ID, job.BacalhauJobID)
 		if len(bacalhauJob.State.Executions) > 0 {
-			return completeJobAndAddOutputFiles(&job, models.JobStateCompleted, bacalhauJob.State.Executions[0].PublishedResult.CID, db)
+			lastExecutionIndex := len(bacalhauJob.State.Executions) - 1
+			return completeJobAndAddOutputFiles(&job, models.JobStateCompleted, bacalhauJob.State.Executions[lastExecutionIndex].PublishedResult.CID, db)
 		}
 		return setJobStatus(&job, models.JobStateFailed, fmt.Sprintf("Output execution data lost for %v", job.BacalhauJobID), db)
 	} else {

--- a/internal/bacalhau/bacalhau.go
+++ b/internal/bacalhau/bacalhau.go
@@ -239,14 +239,15 @@ func JobFailedWithCapacityError(job *model.JobWithInfo) bool {
 	capacityErrorMessages := []string{"not enough capacity", "not enough nodes", "does not have capacity"}
 	falseCapacityMessages := []string{"Could not inspect image", "node does not support the available image platforms"}
 	if len(job.State.Executions) > 0 {
-		fmt.Printf("Checking for capacity error, got error: %v\n", job.State.Executions[0].Status)
+		lastExecutionIndex := len(job.State.Executions) - 1
+		fmt.Printf("Checking for capacity error, got error: %v\n", job.State.Executions[lastExecutionIndex].Status)
 		for _, errorMsg := range falseCapacityMessages {
-			if job.State.State == model.JobStateError && strings.Contains(job.State.Executions[0].Status, errorMsg) {
+			if job.State.State == model.JobStateError && strings.Contains(job.State.Executions[lastExecutionIndex].Status, errorMsg) {
 				return false
 			}
 		}
 		for _, errorMsg := range capacityErrorMessages {
-			if job.State.State == model.JobStateError && strings.Contains(job.State.Executions[0].Status, errorMsg) {
+			if job.State.State == model.JobStateError && strings.Contains(job.State.Executions[lastExecutionIndex].Status, errorMsg) {
 				return true
 			}
 		}
@@ -257,8 +258,9 @@ func JobFailedWithCapacityError(job *model.JobWithInfo) bool {
 func JobFailedWithBidRejectedError(job *model.JobWithInfo) bool {
 	capacityErrorMsg := "bid rejected"
 	if len(job.State.Executions) > 0 {
-		fmt.Printf("Checking for capacity error, got error: %v\n", job.State.Executions[0].Status)
-		return job.State.State == model.JobStateError && strings.Contains(job.State.Executions[0].Status, capacityErrorMsg)
+		lastExecutionIndex := len(job.State.Executions) - 1
+		fmt.Printf("Checking for capacity error, got error: %v\n", job.State.Executions[lastExecutionIndex].Status)
+		return job.State.State == model.JobStateError && strings.Contains(job.State.Executions[lastExecutionIndex].Status, capacityErrorMsg)
 	}
 	return false
 }
@@ -266,7 +268,8 @@ func JobFailedWithBidRejectedError(job *model.JobWithInfo) bool {
 func JobIsRunning(job *model.JobWithInfo) bool {
 	// the backend counts a Job as running once it is accepted by Bacalhau
 	if len(job.State.Executions) > 0 {
-		return job.State.State == model.JobStateInProgress || job.State.Executions[0].State == model.ExecutionStateBidAccepted
+		lastExecutionIndex := len(job.State.Executions) - 1
+		return job.State.State == model.JobStateInProgress || job.State.Executions[lastExecutionIndex].State == model.ExecutionStateBidAccepted
 	} else {
 		return job.State.State == model.JobStateInProgress
 	}
@@ -286,7 +289,8 @@ func JobCancelled(job *model.JobWithInfo) bool {
 
 func JobBidAccepted(job *model.JobWithInfo) bool {
 	if len(job.State.Executions) > 0 {
-		return job.State.Executions[0].State == model.ExecutionStateBidAccepted
+		lastExecutionIndex := len(job.State.Executions) - 1
+		return job.State.Executions[lastExecutionIndex].State == model.ExecutionStateBidAccepted
 	}
 	return false
 }


### PR DESCRIPTION
## What type of PR is this? 

- 🐛 Bug Fix

## Description

 I noticed
 
 ```
 Error listing files in directory: ls: invalid path "": invalid ipfs pathunexpected error monitoring running jobs: ls: invalid path "": invalid ipfs path
 ```
 
In the logs and jobs not processing. I realized this was because a some jobs had multiple bacalhau executions, the first was always a bid rejected capacity error. For these cases we should always look at the most recent execution.

Example

```
State:
  CreateTime: "2024-03-08T15:46:41.301528202Z"
  Executions:
  - ComputeReference: e-46b17748-0ac3-4181-a252-1fe5e78bdc38
    CreateTime: "2024-03-08T15:46:41.308035083Z"
    DesiredState: 2
    JobID: 24df3836-3ad8-4402-91fa-b779595b7528
    NodeId: QmPui6hPRoktGhteDRUSNzrYceEc3R52nZqp82nbd4Kjiy
    PublishedResults: {}
    State: AskForBidRejected
    Status: 'this node does not have capacity to run the job ({CPU: 0.400000, Memory:
      2.5 GB, Disk: 1.7 TB, GPU: 0} requested but only {%!s(float64=3) %!s(uint64=12000000000)
      %!s(uint64=323702) %!s(uint64=1) []} is available). bid rejected'
    UpdateTime: "2024-03-08T15:46:41.430322833Z"
    Version: 3
  - ComputeReference: e-5cbdb18f-6390-49c6-8756-b7132759d9ba
    CreateTime: "2024-03-08T15:46:41.435599426Z"
    DesiredState: 2
    JobID: 24df3836-3ad8-4402-91fa-b779595b7528
    NodeId: QmVakTbjsKHKho6svUTw5Q5yqbojrhbrAAvcJyCscxyLwa
    PublishedResults:
      CID: QmUCD2RKAd8Q8CR8hmixFExGkshcFa6briXqveNeDw44Zu
      StorageSource: ipfs
    RunOutput:
      exitCode: 0
 ```
