### PR TITLE
Admin flow and job accessibility

### DIFF
--- a/gateway/handlers/flows.go
+++ b/gateway/handlers/flows.go
@@ -266,7 +266,13 @@ func GetFlowHandler(db *gorm.DB) http.HandlerFunc {
 		}
 
 		var flow models.Flow
-		if result := db.Preload("Jobs.Tool").First(&flow, "id = ? AND wallet_address = ?", flowID, user.WalletAddress); result.Error != nil {
+		query := db.Preload("Jobs.Tool").Where("id = ?", flowID)
+
+		if !user.Admin {
+			query = query.Where("wallet_address = ?", user.WalletAddress)
+		}
+
+		if result := query.First(&flow); result.Error != nil {
 			if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 				http.Error(w, "Flow not found or not authorized", http.StatusNotFound)
 			} else {

--- a/gateway/handlers/jobs.go
+++ b/gateway/handlers/jobs.go
@@ -39,7 +39,13 @@ func GetJobHandler(db *gorm.DB) http.HandlerFunc {
 		}
 
 		var job models.Job
-		if result := db.Preload("OutputFiles.Tags").Preload("InputFiles.Tags").Where("wallet_address = ?", user.WalletAddress).First(&job, "id = ?", jobID); result.Error != nil {
+		query := db.Preload("OutputFiles.Tags").Preload("InputFiles.Tags").Where("id = ?", jobID)
+
+		if !user.Admin {
+			query = query.Where("wallet_address = ?", user.WalletAddress)
+		}
+
+		if result := query.First(&job); result.Error != nil {
 			if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 				http.Error(w, "Job not found or not authorized", http.StatusNotFound)
 			} else {


### PR DESCRIPTION
## What type of PR is this? 

- 🎮 Feature

## Description

Admin users can now fetch flow and job details for flows they did not author. This will make sharing and debugging Experiments easier.

## Steps to Test

1. Run multiple Experiments across two users
2. Set one of the users to admin
3. With admin user logged in, navigate to one of the non-admin users' Experiments on the frontend. `localhost:3000/experiments/{non-admin-experiment-id}`
4. Confirm admin can access page and Job details like below. The logged in wallet address is different from the user who created the Experiment

![Screenshot 2024-03-10 at 9 12 52 PM](https://github.com/labdao/plex/assets/29086101/a8d619e5-05c2-4eb2-8662-4fc162389408)

