### PR TITLE
Patch - tab refresh, flow order

### DIFF
--- a/frontend/app/experiments/JobDetail.tsx
+++ b/frontend/app/experiments/JobDetail.tsx
@@ -100,10 +100,12 @@ export default function JobDetail({ jobID }: JobDetailProps) {
   }, [jobID, job.State]);
 
   useEffect(() => {
-    if (tool?.ToolJson?.checkpointCompatible) {
-      setActiveTab("metrics");
-    } else {
-      setActiveTab("logs");
+    if (activeTab === ""){
+      if (tool?.ToolJson?.checkpointCompatible) {
+        setActiveTab("metrics");
+      } else {
+        setActiveTab("logs");
+      }
     }
   }, [tool]);
 

--- a/frontend/app/experiments/JobDetail.tsx
+++ b/frontend/app/experiments/JobDetail.tsx
@@ -100,14 +100,14 @@ export default function JobDetail({ jobID }: JobDetailProps) {
   }, [jobID, job.State]);
 
   useEffect(() => {
-    if (activeTab === ""){
+    if (activeTab === "" && tool?.ToolJson){
       if (tool?.ToolJson?.checkpointCompatible) {
         setActiveTab("metrics");
       } else {
         setActiveTab("logs");
       }
     }
-  }, [tool]);
+  }, [tool, activeTab]);
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full @container">

--- a/gateway/handlers/flows.go
+++ b/gateway/handlers/flows.go
@@ -315,6 +315,7 @@ func ListFlowsHandler(db *gorm.DB) http.HandlerFunc {
 		if walletAddress := r.URL.Query().Get("walletAddress"); walletAddress != "" {
 			query = query.Where("wallet_address = ?", walletAddress)
 		}
+		query = query.Order("start_time DESC")
 
 		var flows []models.Flow
 		if result := query.Preload("Jobs").Find(&flows); result.Error != nil {


### PR DESCRIPTION
## What type of PR is this? 

- 🐛 Bug Fix

## Description

2 bugs fixed with this PR:
    1. active tab getting reset to the default (metrics if available / logs) every 5 second with the refresh logic
    2. experiments ordered in ascending order of start_time within each time category