### PR TITLE
LAB-1421 rename flow

### DIFF
--- a/frontend/app/experiments/(experiment)/(forms)/ExperimentRenameForm.tsx
+++ b/frontend/app/experiments/(experiment)/(forms)/ExperimentRenameForm.tsx
@@ -7,24 +7,24 @@ import { z } from "zod";
 
 import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { flowUpdateThunk, useDispatch } from "@/lib/redux";
 
 const formSchema = z.object({
   name: z.string().min(1, { message: "Name is required" }),
 });
 
-export function ExperimentRenameForm({ initialName, inputProps }: { initialName: string; inputProps?: any }) {
+export function ExperimentRenameForm({ initialName, inputProps, flowId }: { initialName: string; inputProps?: any; flowId: string }) {
+  const dispatch = useDispatch();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: {
-      name: initialName,
-    },
+    defaultValues: { name: initialName },
     mode: "onChange",
   });
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
-    toast.warning("Renaming experiments is coming soon!", { position: "top-center" });
-    console.log(values);
-  }
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    await dispatch(flowUpdateThunk({ flowId, updates: { name: values.name } }));
+    toast.success("Experiment renamed successfully!");
+  };
 
   return (
     <Form {...form}>

--- a/frontend/app/experiments/(experiment)/[flowID]/ExperimentDetail.tsx
+++ b/frontend/app/experiments/(experiment)/[flowID]/ExperimentDetail.tsx
@@ -54,7 +54,9 @@ export default function ExperimentDetail() {
   const handlePublish = () => {
     setIsDelaying(true);
     if (experimentID) {
-      dispatch(flowUpdateThunk({ flowId: experimentID })).then(() => {
+      dispatch(flowUpdateThunk({ flowId: experimentID, updates: { public: true } }))
+      .unwrap()
+      .then(() => {
         setTimeout(() => {
           dispatch(setFlowDetailPublic(true));
           setIsDelaying(false);
@@ -68,7 +70,7 @@ export default function ExperimentDetail() {
 
   const isButtonDisabled = updateLoading || isDelaying;
 
-  return flow.Name ? (
+  return flow.Name && experimentID ? (
     <div>
       <>
         <Card>
@@ -79,7 +81,7 @@ export default function ExperimentDetail() {
                 <ExperimentStatus jobs={flow.Jobs} className="mr-1 mt-3.5" />
                 <ExperimentRenameForm
                   initialName={flow.Name}
-                  key={flow.Name}
+                  flowId={experimentID}
                   inputProps={{ variant: "subtle", className: "text-xl shrink-0 font-heading w-full" }}
                 />
               </div>

--- a/frontend/components/global/Nav.tsx
+++ b/frontend/components/global/Nav.tsx
@@ -17,6 +17,7 @@ import { Button } from "../ui/button";
 import { cn } from "@/lib/utils";
 import { useParams } from "next/navigation";
 import { toast } from "sonner";
+import { InlineEditExperiment } from "@/components/ui/inline-edit-experiment";
 
 export default function Nav() {
   const { user } = usePrivy();
@@ -72,16 +73,7 @@ export default function Nav() {
                         flowID === flow.ID.toString() && "text-foreground bg-muted hover:bg-muted"
                       )}
                     >
-                      {flow.Name}
-                      {/* With renaming functionality in the experiment title (ExperimentRenameForm) this may be unnecessary */}
-                      <Button
-                        onClick={() => toast.warning("Renaming experiments is coming soon!", { position: "top-center" })}
-                        variant="secondary"
-                        size="icon"
-                        className="absolute hidden group-hover:block top-[2px] right-[2px]"
-                      >
-                        <PencilIcon />
-                      </Button>
+                      <InlineEditExperiment flow={flow} />
                     </Link>
                   ))}
                 </div>

--- a/frontend/components/ui/inline-edit-experiment.tsx
+++ b/frontend/components/ui/inline-edit-experiment.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { PencilIcon, CheckIcon } from "lucide-react";
+import { AppDispatch, flowUpdateThunk } from '@/lib/redux';
+
+interface Flow {
+    ID: number;
+    Name: string;
+}
+
+interface InlineEditExperimentProps {
+    flow: Flow;
+}
+
+export const InlineEditExperiment: React.FC<InlineEditExperimentProps> = ({ flow }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [name, setName] = useState(flow.Name);
+  const dispatch: AppDispatch = useDispatch();
+
+  const handleRename = () => {
+    const action = flowUpdateThunk({
+        flowId: flow.ID.toString(),
+        updates: { name }
+      });
+      dispatch(action);
+      setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="flex items-center space-x-2">
+        <input
+          type="text"
+          className="text-sm px-2 py-1 rounded"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={handleRename}
+        />
+        <button onClick={handleRename} className="text-green-500">
+          <CheckIcon size={16} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between">
+      <span>{name}</span>
+      <button onClick={() => setIsEditing(true)} className="text-gray-500">
+        <PencilIcon size={16} />
+      </button>
+    </div>
+  );
+};
+

--- a/frontend/components/ui/inline-edit-experiment.tsx
+++ b/frontend/components/ui/inline-edit-experiment.tsx
@@ -44,9 +44,9 @@ export const InlineEditExperiment: React.FC<InlineEditExperimentProps> = ({ flow
   }
 
   return (
-    <div className="flex items-center justify-between">
-      <span>{name}</span>
-      <button onClick={() => setIsEditing(true)} className="text-gray-500">
+    <div className="flex items-center">
+      <span className="flex-1 mr-2 truncate">{name}</span>
+      <button onClick={() => setIsEditing(true)} className="absolute hidden group-hover:block right-[2px]">
         <PencilIcon size={16} />
       </button>
     </div>

--- a/frontend/lib/redux/slices/flowUpdateSlice/asyncActions.ts
+++ b/frontend/lib/redux/slices/flowUpdateSlice/asyncActions.ts
@@ -1,7 +1,7 @@
 import { getAccessToken } from "@privy-io/react-auth";
 import backendUrl from "lib/backendUrl";
 
-export const updateFlow = async (flowId: string): Promise<any> => {
+export const updateFlow = async (flowId: string, data: { name?: string; public?: boolean; }): Promise<any> => {
   let authToken;
   try {
     authToken = await getAccessToken()
@@ -17,6 +17,7 @@ export const updateFlow = async (flowId: string): Promise<any> => {
       'Authorization': `Bearer ${authToken}`,
       'Content-Type': 'application/json',
     },
+    body: JSON.stringify(data)
   };
 
   try {
@@ -24,8 +25,7 @@ export const updateFlow = async (flowId: string): Promise<any> => {
     if (!response.ok) {
       throw new Error(`Failed to update Flow: ${response.statusText}`);
     }
-    const result = await response.json();
-    return result;
+    return await response.json();
   } catch (error) {
     console.error('Failed to update Flow:', error);
     throw new Error('Failed to update Flow');

--- a/frontend/lib/redux/slices/flowUpdateSlice/thunks.ts
+++ b/frontend/lib/redux/slices/flowUpdateSlice/thunks.ts
@@ -6,14 +6,18 @@ import { setFlowUpdateError, setFlowUpdateLoading, setFlowUpdateSuccess } from '
 
 interface UpdateFlowArgs {
     flowId: string;
+    updates: {
+        name?: string;
+        public?: boolean;
+    };
 }
 
 export const flowUpdateThunk = createAppAsyncThunk(
     'flow/updateFlow',
-    async ({ flowId }: UpdateFlowArgs, { dispatch }: { dispatch: AppDispatch }) => {
+    async ({ flowId, updates }: UpdateFlowArgs, { dispatch }: { dispatch: AppDispatch }) => {
         dispatch(setFlowUpdateLoading(true));
         try {
-            const result = await updateFlow(flowId);
+            const result = await updateFlow(flowId, updates);
             dispatch(setFlowUpdateSuccess(true));
             return result;
         } catch (error) {

--- a/gateway/handlers/flows.go
+++ b/gateway/handlers/flows.go
@@ -374,55 +374,80 @@ func UpdateFlowHandler(db *gorm.DB) http.HandlerFunc {
 			return
 		}
 
-		if flow.Public {
-			http.Error(w, "Flow is already public", http.StatusBadRequest)
+		var requestData struct {
+			Name   *string `json:"name,omitempty"`
+			Public *bool   `json:"public,omitempty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&requestData); err != nil {
+			http.Error(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
 			return
 		}
 
-		flow.Public = true
-
-		if result := db.Model(&flow).Updates(models.Flow{Public: flow.Public}); result.Error != nil {
-			http.Error(w, fmt.Sprintf("Error updating Flow: %v", result.Error), http.StatusInternalServerError)
-			return
+		newPublicFlag := false
+		newName := ""
+		if requestData.Name != nil {
+			newName = *requestData.Name
 		}
-
-		var jobs []models.Job
-		if result := db.Where("flow_id = ?", flow.ID).Find(&jobs); result.Error != nil {
-			http.Error(w, fmt.Sprintf("Error fetching Jobs: %v", result.Error), http.StatusInternalServerError)
-			return
-		}
-
-		for _, job := range jobs {
-			if result := db.Model(&job).Updates(models.Job{Public: flow.Public}); result.Error != nil {
-				http.Error(w, fmt.Sprintf("Error updating Job: %v", result.Error), http.StatusInternalServerError)
+		if requestData.Public != nil && *requestData.Public != flow.Public {
+			if flow.Public {
+				http.Error(w, "Flow is already public and cannot be made private", http.StatusBadRequest)
 				return
 			}
-
-			if result := db.Model(&models.DataFile{}).Where("cid IN (?)", db.Table("job_input_files").Select("data_file_c_id").Where("job_id = ?", job.ID)).Updates(models.DataFile{Public: flow.Public}); result.Error != nil {
-				http.Error(w, fmt.Sprintf("Error updating input DataFiles: %v", result.Error), http.StatusInternalServerError)
-				return
-			}
-
-			if result := db.Model(&models.DataFile{}).Where("cid IN (?)", db.Table("job_output_files").Select("data_file_c_id").Where("job_id = ?", job.ID)).Updates(models.DataFile{Public: flow.Public}); result.Error != nil {
-				http.Error(w, fmt.Sprintf("Error updating output DataFiles: %v", result.Error), http.StatusInternalServerError)
+			newPublicFlag = *requestData.Public
+		}
+		if newName != "" {
+			flow.Name = newName
+			if result := db.Model(&flow).Updates(models.Flow{Name: flow.Name}); result.Error != nil {
+				http.Error(w, fmt.Sprintf("Error updating Flow: %v", result.Error), http.StatusInternalServerError)
 				return
 			}
 		}
+		if newPublicFlag {
+			flow.Public = true
 
-		log.Println("Generating and storing RecordCID...")
-		metadataCID, err := utils.GenerateAndStoreRecordCID(db, &flow)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("Error generating and storing RecordCID: %v", err), http.StatusInternalServerError)
-			return
-		}
-		log.Printf("Generated and stored RecordCID: %s", metadataCID)
+			if result := db.Model(&flow).Updates(models.Flow{Public: flow.Public}); result.Error != nil {
+				http.Error(w, fmt.Sprintf("Error updating Flow: %v", result.Error), http.StatusInternalServerError)
+				return
+			}
 
-		log.Println("Minting NFT...")
-		if err := utils.MintNFT(db, &flow, metadataCID); err != nil {
-			http.Error(w, fmt.Sprintf("Error minting NFT: %v", err), http.StatusInternalServerError)
-			return
+			var jobs []models.Job
+			if result := db.Where("flow_id = ?", flow.ID).Find(&jobs); result.Error != nil {
+				http.Error(w, fmt.Sprintf("Error fetching Jobs: %v", result.Error), http.StatusInternalServerError)
+				return
+			}
+
+			for _, job := range jobs {
+				if result := db.Model(&job).Updates(models.Job{Public: flow.Public}); result.Error != nil {
+					http.Error(w, fmt.Sprintf("Error updating Job: %v", result.Error), http.StatusInternalServerError)
+					return
+				}
+
+				if result := db.Model(&models.DataFile{}).Where("cid IN (?)", db.Table("job_input_files").Select("data_file_c_id").Where("job_id = ?", job.ID)).Updates(models.DataFile{Public: flow.Public}); result.Error != nil {
+					http.Error(w, fmt.Sprintf("Error updating input DataFiles: %v", result.Error), http.StatusInternalServerError)
+					return
+				}
+
+				if result := db.Model(&models.DataFile{}).Where("cid IN (?)", db.Table("job_output_files").Select("data_file_c_id").Where("job_id = ?", job.ID)).Updates(models.DataFile{Public: flow.Public}); result.Error != nil {
+					http.Error(w, fmt.Sprintf("Error updating output DataFiles: %v", result.Error), http.StatusInternalServerError)
+					return
+				}
+			}
+
+			log.Println("Generating and storing RecordCID...")
+			metadataCID, err := utils.GenerateAndStoreRecordCID(db, &flow)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("Error generating and storing RecordCID: %v", err), http.StatusInternalServerError)
+				return
+			}
+			log.Printf("Generated and stored RecordCID: %s", metadataCID)
+
+			log.Println("Minting NFT...")
+			if err := utils.MintNFT(db, &flow, metadataCID); err != nil {
+				http.Error(w, fmt.Sprintf("Error minting NFT: %v", err), http.StatusInternalServerError)
+				return
+			}
+			log.Println("NFT minted")
 		}
-		log.Println("NFT minted")
 
 		log.Printf("Updated Flow: %+v", flow)
 


### PR DESCRIPTION
## What type of PR is this? 

- 🎮 Feature

## Description

Renaming experiment after submission from the top of the experiment and also with a pencil icon from the side nav like ChatGPT. I also made changes to the updateflowhandler to not only take in public flag but the new name for renaming as well. 
This feature requires a fix later on to get an auto refresh after the experiment is renamed, to get the side nav and the top of the experiment in sync with the latest name.

## Relevant GIF 

![name](https://github.com/labdao/plex/assets/25219071/500c3981-089f-4ade-991b-2edb0846fa2e)

