### PR TITLE
`BuildTokenMetadata` graceful error handling

### DIFF
--- a/gateway/utils/web3.go
+++ b/gateway/utils/web3.go
@@ -101,51 +101,56 @@ func BuildTokenMetadata(db *gorm.DB, flow *models.Flow) (string, error) {
 		log.Printf("Pinning tool JSON to IPFS: %s", tool.Name)
 		toolPinataHash, err := pinJSONToPublicIPFS(json.RawMessage(tool.ToolJson), tool.Name)
 		if err != nil {
-			return "", fmt.Errorf("failed to pin tool JSON to Pinata: %v", err)
-		}
-		log.Printf("Pinned tool JSON to public IPFS with CID: %s", toolPinataHash)
-		ioObject["tool"] = map[string]interface{}{
-			"cid": toolPinataHash,
+			log.Printf("Failed to pin tool JSON to Pinata: %s. Skipping... Error: %v", tool.Name, err)
+		} else {
+			log.Printf("Pinned tool JSON to public IPFS with CID: %s", toolPinataHash)
+			ioObject["tool"] = map[string]interface{}{
+				"cid": toolPinataHash,
+			}
 		}
 
 		for _, inputFile := range inputFiles {
 			log.Printf("Downloading input file: %s", inputFile.Filename)
 			inputTempFilePath, err := ipfs.DownloadFileToTemp(inputFile.CID, inputFile.Filename)
 			if err != nil {
-				return "", fmt.Errorf("failed to download input file: %v", err)
+				log.Printf("Failed to download input file: %s. Skipping... Error: %v", inputFile.Filename, err)
+				continue
 			}
 			defer os.Remove(inputTempFilePath)
 
 			log.Printf("Pinning input file to IPFS: %s", inputFile.Filename)
 			inputPinataHash, err := pinFileToPublicIPFS(inputTempFilePath, inputFile.Filename)
 			if err != nil {
-				return "", fmt.Errorf("failed to pin input file to Pinata: %v", err)
+				log.Printf("Failed to pin input file to Pinata: %s. Skipping... Error: %v", inputFile.Filename, err)
+			} else {
+				log.Printf("Pinned input file to public IPFS with CID: %s", inputPinataHash)
+				ioObject["inputs"] = append(ioObject["inputs"].([]map[string]interface{}), map[string]interface{}{
+					"cid":      inputPinataHash,
+					"filename": inputFile.Filename,
+				})
 			}
-			log.Printf("Pinned input file to public IPFS with CID: %s", inputPinataHash)
-			ioObject["inputs"] = append(ioObject["inputs"].([]map[string]interface{}), map[string]interface{}{
-				"cid":      inputPinataHash,
-				"filename": inputFile.Filename,
-			})
 		}
 
 		for _, outputFile := range outputFiles {
 			log.Printf("Downloading output file: %s", outputFile.Filename)
 			outputTempFilePath, err := ipfs.DownloadFileToTemp(outputFile.CID, outputFile.Filename)
 			if err != nil {
-				return "", fmt.Errorf("failed to download output file: %v", err)
+				log.Printf("Failed to download output file: %s. Skipping... Error: %v", outputFile.Filename, err)
+				continue
 			}
 			defer os.Remove(outputTempFilePath)
 
 			log.Printf("Pinning output file to IPFS: %s", outputFile.Filename)
 			outputPinataHash, err := pinFileToPublicIPFS(outputTempFilePath, outputFile.Filename)
 			if err != nil {
-				return "", fmt.Errorf("failed to pin output file to Pinata: %v", err)
+				log.Printf("Failed to pin output file to Pinata: %s. Skipping... Error: %v", outputFile.Filename, err)
+			} else {
+				log.Printf("Pinned output file to public IPFS with CID: %s", outputPinataHash)
+				ioObject["outputs"] = append(ioObject["outputs"].([]map[string]interface{}), map[string]interface{}{
+					"cid":      outputPinataHash,
+					"filename": outputFile.Filename,
+				})
 			}
-			log.Printf("Pinned output file to public IPFS with CID: %s", outputPinataHash)
-			ioObject["outputs"] = append(ioObject["outputs"].([]map[string]interface{}), map[string]interface{}{
-				"cid":      outputPinataHash,
-				"filename": outputFile.Filename,
-			})
 		}
 
 		metadata["flow"] = append(metadata["flow"].([]map[string]interface{}), ioObject)


### PR DESCRIPTION
## What type of PR is this? 

- 🐛 Bug Fix

## Description

This PR is a continuation to ensure Record publishing works as expected. It introduces soft, graceful error handling for cases when a file cannot be found from a wrapped CID. The backend logs a message and continues instead of silently failing. 

## Related Tickets & Documents

https://github.com/labdao/plex/pull/944
https://github.com/labdao/plex/pull/963

## Steps to Test

Test on staging environments running Colabdesign, which should include a larger number of output files.