### PR TITLE
Patch for empty fields

### DIFF
--- a/gateway/handlers/flows.go
+++ b/gateway/handlers/flows.go
@@ -350,7 +350,7 @@ func ListFlowsHandler(db *gorm.DB) http.HandlerFunc {
 			query = query.Preload("Jobs")
 		}
 
-		var flows []models.Flow
+		var flows []map[string]interface{}
 		if result := query.Find(&flows); result.Error != nil {
 			http.Error(w, fmt.Sprintf("Error fetching Flows: %v", result.Error), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## What type of PR is this? 

- 🐛 Bug Fix


## Description

Response was previously returning empty fields. Patch fixes this.

**Previous response contains empty or null fields**
```
 ✘ aakaash@Aakaashs-MBP  ~/Desktop/code/OPENLAB/plex   main  curl -X GET 'http://localhost:8080/flows?fields=name&walletAddress={wallet-address}' -H 'Authorization: Bearer {API key}' -H 'Content-Type: application/json'
[{"ID":41,"Jobs":null,"Name":"Flow created by Stripe webhook","WalletAddress":"","StartTime":"2024-06-24T23:40:58.668046Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":40,"Jobs":null,"Name":"Flow created by Stripe webhook","WalletAddress":"","StartTime":"2024-06-24T22:36:06.171032Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":39,"Jobs":null,"Name":"Flow created by Stripe webhook","WalletAddress":"","StartTime":"2024-06-20T06:37:12.715377Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":38,"Jobs":null,"Name":"Flow created by Stripe webhook","WalletAddress":"","StartTime":"2024-06-20T06:36:54.604616Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":37,"Jobs":null,"Name":"Flow created by Stripe webhook","WalletAddress":"","StartTime":"2024-06-20T06:34:17.878097Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":36,"Jobs":null,"Name":"Flow created by Stripe webhook","WalletAddress":"","StartTime":"2024-06-20T06:33:57.793654Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":35,"Jobs":null,"Name":"Flow created by Stripe webhook","WalletAddress":"","StartTime":"2024-06-20T06:19:51.497065Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":34,"Jobs":null,"Name":"Flow created by Stripe webhook","WalletAddress":"","StartTime":"2024-06-20T06:17:03.50693Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":33,"Jobs":null,"Name":"Flow created by Stripe webhook","WalletAddress":"","StartTime":"2024-06-20T06:16:43.82177Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":31,"Jobs":null,"Name":"Flow created by Stripe webhook","WalletAddress":"","StartTime":"2024-06-19T13:29:49.93101Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":27,"Jobs":null,"Name":"protein-binder-design-2024-06-18-11-31","WalletAddress":"","StartTime":"2024-06-18T12:11:38.542903Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":26,"Jobs":null,"Name":"protein-binder-design-2024-06-18-07-33","WalletAddress":"","StartTime":"2024-06-18T12:07:42.114895Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":25,"Jobs":null,"Name":"protein-binder-design-2024-06-18-54-08","WalletAddress":"","StartTime":"2024-06-18T11:54:13.657054Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":24,"Jobs":null,"Name":"protein-binder-design-2024-06-17-51-18","WalletAddress":"","StartTime":"2024-06-18T02:51:22.641731Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":23,"Jobs":null,"Name":"protein-binder-design-2024-06-17-36-11","WalletAddress":"","StartTime":"2024-06-18T02:24:10.384469Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":22,"Jobs":null,"Name":"protein-binder-design-2024-06-17-36-11","WalletAddress":"","StartTime":"2024-06-18T02:23:32.649633Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":21,"Jobs":null,"Name":"protein-binder-design-2024-06-17-36-11","WalletAddress":"","StartTime":"2024-06-18T01:36:14.786817Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":20,"Jobs":null,"Name":"protein-binder-design-2024-06-17-35-53","WalletAddress":"","StartTime":"2024-06-18T01:35:56.317746Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":19,"Jobs":null,"Name":"protein-binder-design-2024-06-16-15-09","WalletAddress":"","StartTime":"2024-06-17T03:15:44.622884Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":18,"Jobs":null,"Name":"protein-binder-design-2024-06-16-05-01","WalletAddress":"","StartTime":"2024-06-17T03:05:40.345336Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":17,"Jobs":null,"Name":"protein-binder-design-2024-06-16-14-48","WalletAddress":"","StartTime":"2024-06-17T02:14:55.665363Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":16,"Jobs":null,"Name":"protein-binder-design-2024-06-16-53-00","WalletAddress":"","StartTime":"2024-06-17T01:53:08.745707Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":15,"Jobs":null,"Name":"protein-binder-design-2024-06-13-11-26","WalletAddress":"","StartTime":"2024-06-13T04:11:29.447825Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":14,"Jobs":null,"Name":"protein-binder-design-2024-06-12-54-54","WalletAddress":"","StartTime":"2024-06-13T03:54:58.048659Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":13,"Jobs":null,"Name":"protein-binder-design-2024-06-12-41-10","WalletAddress":"","StartTime":"2024-06-13T03:41:14.326286Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":12,"Jobs":null,"Name":"protein-binder-design-2024-06-12-21-00","WalletAddress":"","StartTime":"2024-06-13T03:21:02.813417Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":11,"Jobs":null,"Name":"protein-binder-design-2024-06-12-06-03","WalletAddress":"","StartTime":"2024-06-13T03:06:08.853759Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":10,"Jobs":null,"Name":"protein-binder-design-2024-06-12-56-28","WalletAddress":"","StartTime":"2024-06-13T02:57:56.38321Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":9,"Jobs":null,"Name":"protein-binder-design-2024-06-12-04-46","WalletAddress":"","StartTime":"2024-06-13T02:05:22.802172Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":8,"Jobs":null,"Name":"protein-binder-design-2024-06-12-16-11","WalletAddress":"","StartTime":"2024-06-13T00:16:24.54536Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":7,"Jobs":null,"Name":"protein-binder-design-2024-06-12-42-32","WalletAddress":"","StartTime":"2024-06-12T23:42:46.241275Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":6,"Jobs":null,"Name":"protein-binder-design-2024-06-12-33-01","WalletAddress":"","StartTime":"2024-06-12T23:33:09.13933Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":5,"Jobs":null,"Name":"protein-binder-design-2024-06-12-55-28","WalletAddress":"","StartTime":"2024-06-12T22:55:32.456509Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":4,"Jobs":null,"Name":"protein-binder-design-2024-06-12-39-15","WalletAddress":"","StartTime":"2024-06-12T20:39:30.201538Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":3,"Jobs":null,"Name":"protein-binder-design-2024-06-12-36-43","WalletAddress":"","StartTime":"2024-06-12T20:36:50.535051Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":2,"Jobs":null,"Name":"protein-binder-design-2024-06-11-47-48","WalletAddress":"","StartTime":"2024-06-11T16:47:51.883353Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""},{"ID":1,"Jobs":null,"Name":"protein-binder-design-2024-06-11-31-17","WalletAddress":"","StartTime":"2024-06-11T16:31:21.271519Z","EndTime":"0001-01-01T00:00:00Z","FlowUUID":"","Public":false,"RecordCID":""}]
```

**With patch, no longer empty fields**
```
 aakaash@Aakaashs-MBP  ~/Desktop/code/OPENLAB/plex   main  curl -X GET 'http://localhost:8080/flows?fields=name&walletAddress={wallet-address}' -H 'Authorization: Bearer {API key}' -H 'Content-Type: application/json'
[{"id":41,"name":"Flow created by Stripe webhook","start_time":"2024-06-24T23:40:58.668046Z"},{"id":40,"name":"Flow created by Stripe webhook","start_time":"2024-06-24T22:36:06.171032Z"},{"id":39,"name":"Flow created by Stripe webhook","start_time":"2024-06-20T06:37:12.715377Z"},{"id":38,"name":"Flow created by Stripe webhook","start_time":"2024-06-20T06:36:54.604616Z"},{"id":37,"name":"Flow created by Stripe webhook","start_time":"2024-06-20T06:34:17.878097Z"},{"id":36,"name":"Flow created by Stripe webhook","start_time":"2024-06-20T06:33:57.793654Z"},{"id":35,"name":"Flow created by Stripe webhook","start_time":"2024-06-20T06:19:51.497065Z"},{"id":34,"name":"Flow created by Stripe webhook","start_time":"2024-06-20T06:17:03.50693Z"},{"id":33,"name":"Flow created by Stripe webhook","start_time":"2024-06-20T06:16:43.82177Z"},{"id":31,"name":"Flow created by Stripe webhook","start_time":"2024-06-19T13:29:49.93101Z"},{"id":27,"name":"protein-binder-design-2024-06-18-11-31","start_time":"2024-06-18T12:11:38.542903Z"},{"id":26,"name":"protein-binder-design-2024-06-18-07-33","start_time":"2024-06-18T12:07:42.114895Z"},{"id":25,"name":"protein-binder-design-2024-06-18-54-08","start_time":"2024-06-18T11:54:13.657054Z"},{"id":24,"name":"protein-binder-design-2024-06-17-51-18","start_time":"2024-06-18T02:51:22.641731Z"},{"id":23,"name":"protein-binder-design-2024-06-17-36-11","start_time":"2024-06-18T02:24:10.384469Z"},{"id":22,"name":"protein-binder-design-2024-06-17-36-11","start_time":"2024-06-18T02:23:32.649633Z"},{"id":21,"name":"protein-binder-design-2024-06-17-36-11","start_time":"2024-06-18T01:36:14.786817Z"},{"id":20,"name":"protein-binder-design-2024-06-17-35-53","start_time":"2024-06-18T01:35:56.317746Z"},{"id":19,"name":"protein-binder-design-2024-06-16-15-09","start_time":"2024-06-17T03:15:44.622884Z"},{"id":18,"name":"protein-binder-design-2024-06-16-05-01","start_time":"2024-06-17T03:05:40.345336Z"},{"id":17,"name":"protein-binder-design-2024-06-16-14-48","start_time":"2024-06-17T02:14:55.665363Z"},{"id":16,"name":"protein-binder-design-2024-06-16-53-00","start_time":"2024-06-17T01:53:08.745707Z"},{"id":15,"name":"protein-binder-design-2024-06-13-11-26","start_time":"2024-06-13T04:11:29.447825Z"},{"id":14,"name":"protein-binder-design-2024-06-12-54-54","start_time":"2024-06-13T03:54:58.048659Z"},{"id":13,"name":"protein-binder-design-2024-06-12-41-10","start_time":"2024-06-13T03:41:14.326286Z"},{"id":12,"name":"protein-binder-design-2024-06-12-21-00","start_time":"2024-06-13T03:21:02.813417Z"},{"id":11,"name":"protein-binder-design-2024-06-12-06-03","start_time":"2024-06-13T03:06:08.853759Z"},{"id":10,"name":"protein-binder-design-2024-06-12-56-28","start_time":"2024-06-13T02:57:56.38321Z"},{"id":9,"name":"protein-binder-design-2024-06-12-04-46","start_time":"2024-06-13T02:05:22.802172Z"},{"id":8,"name":"protein-binder-design-2024-06-12-16-11","start_time":"2024-06-13T00:16:24.54536Z"},{"id":7,"name":"protein-binder-design-2024-06-12-42-32","start_time":"2024-06-12T23:42:46.241275Z"},{"id":6,"name":"protein-binder-design-2024-06-12-33-01","start_time":"2024-06-12T23:33:09.13933Z"},{"id":5,"name":"protein-binder-design-2024-06-12-55-28","start_time":"2024-06-12T22:55:32.456509Z"},{"id":4,"name":"protein-binder-design-2024-06-12-39-15","start_time":"2024-06-12T20:39:30.201538Z"},{"id":3,"name":"protein-binder-design-2024-06-12-36-43","start_time":"2024-06-12T20:36:50.535051Z"},{"id":2,"name":"protein-binder-design-2024-06-11-47-48","start_time":"2024-06-11T16:47:51.883353Z"},{"id":1,"name":"protein-binder-design-2024-06-11-31-17","start_time":"2024-06-11T16:31:21.271519Z"}]
```