### PR TITLE
Queue (multiple redundant job submission) + UI file upload false WHERE error fixes

### DIFF
--- a/gateway/app.go
+++ b/gateway/app.go
@@ -105,6 +105,15 @@ func ServeWebApp() {
 		panic("failed to connect to database")
 	}
 
+	// Configure connection pool
+	sqlDB, err := db.DB()
+	if err != nil {
+		panic("failed to configure database connection pool")
+	}
+	sqlDB.SetMaxIdleConns(10)           // Set the maximum number of idle connections
+	sqlDB.SetMaxOpenConns(25)           // Set the maximum number of open connections
+	sqlDB.SetConnMaxLifetime(time.Hour) // Connections are recycled every hour
+
 	// Migrate the schema
 	if err := db.AutoMigrate(&models.File{}, &models.User{}, &models.Model{}, &models.Job{}, &models.Tag{}, &models.Transaction{}, &models.InferenceEvent{}, &models.FileEvent{}, &models.UserEvent{}, &models.Organization{}, &models.Design{}); err != nil {
 		panic(fmt.Sprintf("failed to migrate database: %v", err))

--- a/gateway/handlers/files.go
+++ b/gateway/handlers/files.go
@@ -142,17 +142,17 @@ func AddFileHandler(db *gorm.DB, s3c *s3.S3Client) http.HandlerFunc {
 				utils.SendJSONError(w, fmt.Sprintf("Error associating file with user: %v", err), http.StatusInternalServerError)
 				return
 			}
-		}
 
-		var uploadedTag models.Tag
-		if err := db.Where("name = ?", "uploaded").First(&uploadedTag).Error; err != nil {
-			utils.SendJSONError(w, "Tag 'uploaded' not found", http.StatusInternalServerError)
-			return
-		}
+			var uploadedTag models.Tag
+			if err := db.Where("name = ?", "uploaded").First(&uploadedTag).Error; err != nil {
+				utils.SendJSONError(w, "Tag 'uploaded' not found", http.StatusInternalServerError)
+				return
+			}
 
-		if err := db.Model(&file).Association("Tags").Append([]models.Tag{uploadedTag}); err != nil {
-			utils.SendJSONError(w, fmt.Sprintf("Error adding tag to file: %v", err), http.StatusInternalServerError)
-			return
+			if err := db.Model(&file).Association("Tags").Append([]models.Tag{uploadedTag}); err != nil {
+				utils.SendJSONError(w, fmt.Sprintf("Error adding tag to file: %v", err), http.StatusInternalServerError)
+				return
+			}
 		}
 
 		utils.SendJSONResponseWithID(w, file.ID)

--- a/gateway/handlers/jobs.go
+++ b/gateway/handlers/jobs.go
@@ -77,7 +77,7 @@ type Summary struct {
 type AggregatedData struct {
 	JobStatus models.JobState `gorm:"column:job_status"`
 	Count     int
-	JobType   models.JobType `gorm:"column:job_type"`
+	// JobType   models.JobType `gorm:"column:job_type"`
 }
 
 func GetJobsQueueSummaryHandler(db *gorm.DB) http.HandlerFunc {
@@ -86,11 +86,12 @@ func GetJobsQueueSummaryHandler(db *gorm.DB) http.HandlerFunc {
 		var aggregatedResults []AggregatedData
 
 		// Perform the query using GORM
+		// add job type here to group by jobTypeJob and jobTypeService when incorporating ray jobs
 		db = db.Debug()
 		result := db.Table("jobs").
-			Select("jobs.job_type, jobs.job_status, count(*) as count").
+			Select("jobs.job_status, count(*) as count").
 			Joins("left join models on models.id = jobs.model_id").
-			Group("jobs.job_type, jobs.job_status").
+			Group("jobs.job_status").
 			Find(&aggregatedResults)
 		fmt.Printf("Aggregated Results: %+v\n", aggregatedResults)
 

--- a/gateway/handlers/jobs.go
+++ b/gateway/handlers/jobs.go
@@ -119,3 +119,7 @@ func GetJobsQueueSummaryHandler(db *gorm.DB) http.HandlerFunc {
 		json.NewEncoder(w).Encode(summary)
 	}
 }
+
+func GetWorkerSummaryHandler(w http.ResponseWriter, r *http.Request) {
+	utils.GetWorkerSummary(w, r)
+}

--- a/gateway/models/job.go
+++ b/gateway/models/job.go
@@ -14,6 +14,7 @@ const (
 	JobStateRunning   JobState = "running"
 	JobStateFailed    JobState = "failed"
 	JobStateCompleted JobState = "completed"
+	JobStateStopped   JobState = "stopped"
 )
 
 type QueueType string

--- a/gateway/models/job.go
+++ b/gateway/models/job.go
@@ -10,6 +10,7 @@ type JobState string
 
 const (
 	JobStateQueued    JobState = "queued"
+	JobStatePending   JobState = "pending"
 	JobStateRunning   JobState = "running"
 	JobStateFailed    JobState = "failed"
 	JobStateCompleted JobState = "completed"

--- a/gateway/server/server.go
+++ b/gateway/server/server.go
@@ -65,6 +65,7 @@ func NewServer(db *gorm.DB, s3c *s3.S3Client) *mux.Router {
 	router.HandleFunc("/jobs/{jobID}", protected(handlers.GetJobHandler(db))).Methods("GET")
 	// router.HandleFunc("/jobs/{bacalhauJobID}/logs", handlers.StreamJobLogsHandler).Methods("GET")
 	router.HandleFunc("/queue-summary", handlers.GetJobsQueueSummaryHandler(db)).Methods("GET")
+	router.HandleFunc("/worker-summary", handlers.GetWorkerSummaryHandler).Methods("GET")
 
 	router.HandleFunc("/tags", protected(handlers.AddTagHandler(db))).Methods("POST")
 	router.HandleFunc("/tags", protected(handlers.ListTagsHandler(db))).Methods("GET")

--- a/internal/ray/ray.go
+++ b/internal/ray/ray.go
@@ -132,7 +132,6 @@ func validateInputKeys(inputVectors map[string]interface{}, modelInputs map[stri
 }
 
 func SubmitRayJob(modelPath string, rayJobID string, inputs map[string]interface{}, db *gorm.DB) (*http.Response, error) {
-	log.Printf("Creating Ray job with modelPath: %s and inputs: %+v\n", modelPath, inputs)
 	resp, err := CreateRayJob(modelPath, rayJobID, inputs, db)
 	if err != nil {
 		log.Printf("Error creating Ray job: %v\n", err)


### PR DESCRIPTION
## What type of PR is this? 

- 🎮 Feature
- 🐛 Bug Fix

## Description

1. A minor change in files.go to fix the false error "WHERE condition is required": This was happening because the handler was trying to upload tags for existing files without a where condition. I moved it inside the block where we upload tags only for newly uploaded files, and for existing file, only add a user_file record.
2. Fix for multiple redundant job submissions when only one job is submitted: I changed queue initiated processRayJob calls to worker initiated calls. Also fixed spinning up endless workers by adding a once check, so we only spin up MAX_WORKERS number of workers. With this fix, going forward the workers, when free, calls the processRayJob. And the method fetchOldestQueuedJob is now updated to fetch and update the oldest queued job to "Pending" state. This introduces a new state "Pending" into the list of possible job statuses.
3. Similar to /queue-summary, there is now a /worker-summary that shows the job handled by each worker. This was introduced to double check that the same job is not processed by multiple workers. (This should already be fixed with the fetch and mark as pending change). 
4. Stopping dangling jobs after an hour: With Ray Services, there is an issue where during the initial boot up, jobs more than the MAX_WORKER value get picked up, and the excessive jobs go dangling as it proceeds with the queue to the next set of jobs. This is fixed by introducing an intervention where the queue fetches the oldest running job and marks it as "stopped" which is different from "failed". This change introduces a new state "stopped" into the list of possible job statuses. It is important we are able to differentiate between ray failed jobs and manual intervened stopped jobs for our analysis later.

<b>Note: This above change will be incorporated with the upcoming stripe PR to not charge users for manually stopped dangling jobs.<b>

![image](https://github.com/user-attachments/assets/baa4b70e-ecf0-4bcc-a37d-60f6a6c42cfe)

## Steps to Test

Successful test should spin up only MAX_WORKERS no. of containers per service. And the remaining jobs should stay in queued state. There shouldn't be endless scaling up (till the max scale up capacity) and showing all the jobs submitted as running.
Dangling jobs should be marked as stopped after an hour.
Dangling jobs stopped example: (this can be tested by setting `1*time.Hour` to a lesser time in`fetchAndMarkOldestRunningJobAsStopped` function
<img width="953" alt="image" src="https://github.com/user-attachments/assets/920c9795-5872-4d54-8c05-ee56a718faeb">