### PR TITLE
Parsing 404 job not found correctly in getrayjobstatus

### DIFF
--- a/internal/ray/ray.go
+++ b/internal/ray/ray.go
@@ -179,15 +179,18 @@ func GetRayJobStatus(rayJobID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("error getting job status: %s", string(body))
+	}
 	log.Printf("Ray job status response: %s\n", string(body))
 	var data map[string]interface{}
 	if err := json.Unmarshal(body, &data); err != nil {
-		log.Fatalf("Error parsing JSON: %s", err)
+		return "", err
 	}
 
 	status, ok := data["status"]
 	if !ok {
-		log.Fatal("Status field not found")
+		return "", fmt.Errorf("status key not found in response: %v", data)
 	}
 	return status.(string), nil
 }


### PR DESCRIPTION
## What type of PR is this? 

- 🐛 Bug Fix

## Description

The GetRayJobStatus() function part of the go routine MonitorRunningJobs fetches all the jobs with running status from the database and uses the ray job ID (submission ID) to fetch the status of the job. However, after we deploy a new version of the base ray job on testeks, it loses the previous state, and returns a 404 job not found to the gateway. This was causing a CrashLoopBackoff on the backend container. To fix this, now the GetRayJobStatus() handles this scenario properly and marks the job as failed and moves on instead of crashing.

<img width="709" alt="image" src="https://github.com/user-attachments/assets/6de68fa1-5415-458f-bb41-9db8b4f0edcb">
<img width="748" alt="image" src="https://github.com/user-attachments/assets/91c5fa6b-307d-4f1f-b657-e428c1a5da27">


After deploying to test:
![image](https://github.com/user-attachments/assets/950af284-c70c-498b-9602-69e411cc72f8)

